### PR TITLE
feat: user workspace isolation based on GitHub authentication

### DIFF
--- a/frontend/src/app/repos/page.tsx
+++ b/frontend/src/app/repos/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
 import { Header } from "@/components/layout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -24,7 +25,12 @@ import {
 import { api, type Repository } from "@/lib/api";
 import { formatDate, cn, truncate } from "@/lib/utils";
 
+// Default user ID for guests (not logged in)
+const GUEST_USER_ID = 1;
+
 export default function ReposPage() {
+  const { data: session } = useSession();
+  const userId = (session?.user as { numericId?: number })?.numericId ?? GUEST_USER_ID;
   const [repos, setRepos] = useState<Repository[]>([]);
   const [selectedRepo, setSelectedRepo] = useState<Repository | null>(null);
   const [showCloneModal, setShowCloneModal] = useState(false);
@@ -35,7 +41,7 @@ export default function ReposPage() {
   useEffect(() => {
     const fetchRepos = async () => {
       try {
-        const data = await api.getRepositories(1);
+        const data = await api.getRepositories(userId);
         setRepos(data);
       } catch (error) {
         console.error("Failed to fetch repos:", error);
@@ -45,7 +51,7 @@ export default function ReposPage() {
     };
 
     fetchRepos();
-  }, []);
+  }, [userId]);
 
   const filteredRepos = repos.filter(
     (r) =>
@@ -146,7 +152,7 @@ export default function ReposPage() {
         {/* Repo Detail */}
         <div className="flex-1 overflow-hidden">
           {selectedRepo ? (
-            <RepoDetail repo={selectedRepo} />
+            <RepoDetail userId={userId} repo={selectedRepo} />
           ) : (
             <div className="h-full flex items-center justify-center text-muted-foreground">
               <div className="text-center">
@@ -159,8 +165,8 @@ export default function ReposPage() {
         </div>
 
         {/* Modals */}
-        {showCloneModal && <CloneModal onClose={() => setShowCloneModal(false)} />}
-        {showNewModal && <NewRepoModal onClose={() => setShowNewModal(false)} />}
+        {showCloneModal && <CloneModal userId={userId} onClose={() => setShowCloneModal(false)} />}
+        {showNewModal && <NewRepoModal userId={userId} onClose={() => setShowNewModal(false)} />}
       </div>
     </>
   );
@@ -207,10 +213,10 @@ function RepoListItem({
   );
 }
 
-function RepoDetail({ repo }: { repo: Repository }) {
+function RepoDetail({ userId, repo }: { userId: number; repo: Repository }) {
   const handleSwitch = async () => {
     try {
-      await api.switchRepository(1, repo.id);
+      await api.switchRepository(userId, repo.id);
     } catch (error) {
       console.error("Failed to switch repo:", error);
     }
@@ -307,7 +313,7 @@ function InfoRow({
   );
 }
 
-function CloneModal({ onClose }: { onClose: () => void }) {
+function CloneModal({ userId, onClose }: { userId: number; onClose: () => void }) {
   const [gitUrl, setGitUrl] = useState("");
   const [name, setName] = useState("");
   const [branch, setBranch] = useState("");
@@ -319,7 +325,7 @@ function CloneModal({ onClose }: { onClose: () => void }) {
 
     setLoading(true);
     try {
-      await api.cloneRepository(1, gitUrl, name || undefined, branch || undefined);
+      await api.cloneRepository(userId, gitUrl, name || undefined, branch || undefined);
       onClose();
     } catch (error) {
       console.error("Failed to clone:", error);
@@ -383,7 +389,7 @@ function CloneModal({ onClose }: { onClose: () => void }) {
   );
 }
 
-function NewRepoModal({ onClose }: { onClose: () => void }) {
+function NewRepoModal({ userId, onClose }: { userId: number; onClose: () => void }) {
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -393,7 +399,7 @@ function NewRepoModal({ onClose }: { onClose: () => void }) {
 
     setLoading(true);
     try {
-      await api.createRepository(1, name);
+      await api.createRepository(userId, name);
       onClose();
     } catch (error) {
       console.error("Failed to create:", error);

--- a/frontend/src/components/chat/add-workspace-modal.tsx
+++ b/frontend/src/components/chat/add-workspace-modal.tsx
@@ -19,12 +19,14 @@ interface AddWorkspaceModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onWorkspaceCreated?: (workspaceId: string) => void;
+  userId: number;
 }
 
 export function AddWorkspaceModal({
   open,
   onOpenChange,
   onWorkspaceCreated,
+  userId,
 }: AddWorkspaceModalProps) {
   const [mode, setMode] = useState<Mode>("select");
   const [gitUrl, setGitUrl] = useState("");
@@ -73,7 +75,7 @@ export function AddWorkspaceModal({
     try {
       const normalizedUrl = normalizeGitUrl(gitUrl);
       const repo = await api.cloneRepository(
-        1,
+        userId,
         normalizedUrl,
         repoName.trim() || undefined,
         branch.trim() || undefined
@@ -97,7 +99,7 @@ export function AddWorkspaceModal({
     setError(null);
 
     try {
-      const repo = await api.createRepository(1, repoName.trim(), {
+      const repo = await api.createRepository(userId, repoName.trim(), {
         createGithub: true,
         isPrivate,
       });

--- a/frontend/src/components/chat/chat-layout.tsx
+++ b/frontend/src/components/chat/chat-layout.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, createContext, useContext, useCallback, useRef } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ServerBar } from "./server-bar";
 import { ChatSidebar } from "./chat-sidebar";
@@ -13,7 +14,13 @@ export type { DraftSession };
 
 type SidebarTab = "chat" | "folders" | "history";
 
+// Default user ID for guests (not logged in)
+const GUEST_USER_ID = 1;
+
 interface ChatContextType {
+  // User ID for API calls (from auth or guest)
+  userId: number;
+  isAuthenticated: boolean;
   activeWorkspace: string;
   setActiveWorkspace: (id: string) => void;
   activeSession: SessionId;
@@ -61,7 +68,12 @@ export function ChatLayout({ children }: ChatLayoutProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const { data: session, status: authStatus } = useSession();
   const isInitializedRef = useRef(false);
+
+  // Get user ID from session or use guest ID
+  const userId = (session?.user as { numericId?: number })?.numericId ?? GUEST_USER_ID;
+  const isAuthenticated = authStatus === "authenticated";
 
   const [activeWorkspace, setActiveWorkspaceState] = useState<string>("");
   const [activeSession, setActiveSessionState] = useState<SessionId>("");
@@ -281,7 +293,7 @@ export function ChatLayout({ children }: ChatLayoutProps) {
 
     const fetchRepository = async () => {
       try {
-        const repos = await api.getRepositories(1);
+        const repos = await api.getRepositories(userId);
         const repo = repos.find((r) => r.id === activeWorkspace);
         setCurrentRepository(repo || null);
       } catch {
@@ -290,11 +302,13 @@ export function ChatLayout({ children }: ChatLayoutProps) {
     };
 
     fetchRepository();
-  }, [activeWorkspace]);
+  }, [userId, activeWorkspace]);
 
   return (
     <ChatContext.Provider
       value={{
+        userId,
+        isAuthenticated,
         activeWorkspace,
         setActiveWorkspace,
         activeSession,
@@ -340,6 +354,7 @@ export function ChatLayout({ children }: ChatLayoutProps) {
             ${isMobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
           `}>
             <ServerBar
+              userId={userId}
               activeWorkspace={activeWorkspace}
               onWorkspaceSelect={(id) => {
                 setActiveWorkspace(id);
@@ -390,6 +405,7 @@ export function ChatLayout({ children }: ChatLayoutProps) {
           {/* Desktop Server Bar */}
           <div className="hidden md:block">
             <ServerBar
+              userId={userId}
               activeWorkspace={activeWorkspace}
               onWorkspaceSelect={(id) => {
                 setActiveWorkspace(id);

--- a/frontend/src/components/chat/chat-sidebar.tsx
+++ b/frontend/src/components/chat/chat-sidebar.tsx
@@ -101,7 +101,7 @@ export function ChatSidebar({
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
-  const { isMobileSidebarOpen, closeMobileSidebar } = useChatContext();
+  const { userId, isMobileSidebarOpen, closeMobileSidebar } = useChatContext();
 
   // Handle resize drag
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -139,7 +139,7 @@ export function ChatSidebar({
   useEffect(() => {
     const fetchSessions = async () => {
       try {
-        const tasks = await api.getTasks(1);
+        const tasks = await api.getTasks(userId);
 
         // Filter tasks by repository path (only show tasks for current workspace)
         const filteredTasks = repositoryPath
@@ -227,7 +227,7 @@ export function ChatSidebar({
     fetchSessions();
     const interval = setInterval(fetchSessions, 5000);
     return () => clearInterval(interval);
-  }, [draftSessions, customSessionNames, sessionOrder, repositoryId, repositoryPath, onSessionsLoaded]);
+  }, [userId, draftSessions, customSessionNames, sessionOrder, repositoryId, repositoryPath, onSessionsLoaded]);
 
   // Fetch file tree when repository changes (with auto-refresh)
   useEffect(() => {
@@ -238,7 +238,7 @@ export function ChatSidebar({
 
     const fetchFileTree = async () => {
       try {
-        const tree = await api.getFileTree(1, repositoryId);
+        const tree = await api.getFileTree(userId, repositoryId);
         setFileTree(tree);
       } catch {
         // Repository may not exist yet - show empty tree
@@ -249,7 +249,7 @@ export function ChatSidebar({
     fetchFileTree();
     const interval = setInterval(fetchFileTree, 10000); // Refresh every 10s
     return () => clearInterval(interval);
-  }, [repositoryId, fileTreeVersion]);
+  }, [userId, repositoryId, fileTreeVersion]);
 
   const toggleFolder = (path: string) => {
     setExpandedFolders((prev) => {

--- a/frontend/src/components/chat/file-viewer.tsx
+++ b/frontend/src/components/chat/file-viewer.tsx
@@ -5,6 +5,7 @@ import { X, FileCode, Copy, Check, Pencil, Save, Undo2, Loader2, Image, FileText
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { api } from "@/lib/api";
+import { useChatContext } from "./chat-layout";
 
 interface FileViewerProps {
   repositoryId: string;
@@ -47,6 +48,7 @@ function getFileIcon(fileType: FileType) {
 }
 
 export function FileViewer({ repositoryId, filePath, onClose }: FileViewerProps) {
+  const { userId } = useChatContext();
   const [content, setContent] = useState<string>("");
   const [originalContent, setOriginalContent] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -64,7 +66,7 @@ export function FileViewer({ repositoryId, filePath, onClose }: FileViewerProps)
 
   // Build raw file URL for binary files
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5555";
-  const rawFileUrl = `${apiBase}/api/repositories/${repositoryId}/file/raw?userId=1&path=${encodeURIComponent(filePath)}`;
+  const rawFileUrl = `${apiBase}/api/repositories/${repositoryId}/file/raw?userId=${userId}&path=${encodeURIComponent(filePath)}`;
 
   useEffect(() => {
     // Only fetch content for text files
@@ -77,7 +79,7 @@ export function FileViewer({ repositoryId, filePath, onClose }: FileViewerProps)
       setLoading(true);
       setError(null);
       try {
-        const result = await api.getFileContent(1, repositoryId, filePath);
+        const result = await api.getFileContent(userId, repositoryId, filePath);
         setContent(result.content);
         setOriginalContent(result.content);
       } catch (err) {
@@ -88,7 +90,7 @@ export function FileViewer({ repositoryId, filePath, onClose }: FileViewerProps)
     };
 
     fetchContent();
-  }, [repositoryId, filePath, fileType]);
+  }, [userId, repositoryId, filePath, fileType]);
 
   // Focus textarea when entering edit mode
   useEffect(() => {
@@ -107,7 +109,7 @@ export function FileViewer({ repositoryId, filePath, onClose }: FileViewerProps)
     setSaving(true);
     setError(null);
     try {
-      await api.saveFileContent(1, repositoryId, filePath, content);
+      await api.saveFileContent(userId, repositoryId, filePath, content);
       setOriginalContent(content);
       setIsEditing(false);
     } catch (err) {

--- a/frontend/src/components/chat/server-bar.tsx
+++ b/frontend/src/components/chat/server-bar.tsx
@@ -8,6 +8,7 @@ import { AddWorkspaceModal } from "./add-workspace-modal";
 import { api, type Repository } from "@/lib/api";
 
 interface ServerBarProps {
+  userId: number;
   activeWorkspace?: string;
   onWorkspaceSelect?: (id: string) => void;
 }
@@ -21,15 +22,15 @@ function getRepoIcon(name: string): string {
   return name.slice(0, 2).toUpperCase();
 }
 
-export function ServerBar({ activeWorkspace, onWorkspaceSelect }: ServerBarProps) {
+export function ServerBar({ userId, activeWorkspace, onWorkspaceSelect }: ServerBarProps) {
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [repositories, setRepositories] = useState<Repository[]>([]);
 
-  // Fetch repositories
+  // Fetch repositories for current user
   useEffect(() => {
     const fetchRepositories = async () => {
       try {
-        const repos = await api.getRepositories(1);
+        const repos = await api.getRepositories(userId);
         setRepositories(repos);
 
         // Auto-select first repository if none selected and repos exist
@@ -45,12 +46,12 @@ export function ServerBar({ activeWorkspace, onWorkspaceSelect }: ServerBarProps
     fetchRepositories();
     const interval = setInterval(fetchRepositories, 10000);
     return () => clearInterval(interval);
-  }, [activeWorkspace, onWorkspaceSelect]);
+  }, [userId, activeWorkspace, onWorkspaceSelect]);
 
   const handleWorkspaceCreated = (workspaceId: string) => {
     onWorkspaceSelect?.(workspaceId);
     // Refresh repositories list
-    api.getRepositories(1).then(setRepositories).catch(() => {});
+    api.getRepositories(userId).then(setRepositories).catch(() => {});
   };
 
   return (
@@ -59,6 +60,7 @@ export function ServerBar({ activeWorkspace, onWorkspaceSelect }: ServerBarProps
         open={addModalOpen}
         onOpenChange={setAddModalOpen}
         onWorkspaceCreated={handleWorkspaceCreated}
+        userId={userId}
       />
       <div className="w-[68px] bg-secondary/50 flex flex-col items-center py-3 gap-2 border-r border-border">
         {/* Repositories */}

--- a/frontend/src/components/chat/sidebar/folders-tab.tsx
+++ b/frontend/src/components/chat/sidebar/folders-tab.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { api, type FileNode } from "@/lib/api";
 import { FilePlus, Plus, X, Loader2 } from "lucide-react";
 import { FileTreeNode } from "./file-tree-node";
+import { useChatContext } from "../chat-layout";
 
 interface FoldersTabProps {
   fileTree: FileNode[];
@@ -17,6 +18,7 @@ interface FoldersTabProps {
 }
 
 export function FoldersTab({ fileTree, expandedFolders, onToggleFolder, onFileSelect, repositoryId, onFileCreated }: FoldersTabProps) {
+  const { userId } = useChatContext();
   const [isCreating, setIsCreating] = useState(false);
   const [newFilePath, setNewFilePath] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -29,7 +31,7 @@ export function FoldersTab({ fileTree, expandedFolders, onToggleFolder, onFileSe
     setError(null);
 
     try {
-      await api.saveFileContent(1, repositoryId, newFilePath.trim(), "");
+      await api.saveFileContent(userId, repositoryId, newFilePath.trim(), "");
       onFileCreated?.();
       onFileSelect?.(newFilePath.trim());
       setNewFilePath("");

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,6 +2,21 @@ import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 
+/**
+ * Generate a consistent numeric user ID from a provider's string ID.
+ * Uses a simple hash to convert the string to a positive integer.
+ */
+function generateNumericUserId(providerId: string): number {
+  let hash = 0;
+  for (let i = 0; i < providerId.length; i++) {
+    const char = providerId.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  // Ensure positive number and reasonable range
+  return Math.abs(hash) % 2147483647 || 1;
+}
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   // Required for production deployments (Netlify, Vercel, etc.)
   trustHost: true,
@@ -20,19 +35,23 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     error: "/login", // Redirect auth errors to login page
   },
   callbacks: {
-    authorized({ auth, request: { nextUrl } }) {
+    authorized() {
       // Allow all routes - auth is optional
       return true;
     },
-    jwt({ token, user }) {
-      if (user) {
+    jwt({ token, user, account }) {
+      if (user && account) {
+        // Store both the original provider ID and generate a numeric ID
         token.id = user.id;
+        token.numericId = generateNumericUserId(`${account.provider}:${user.id}`);
       }
       return token;
     },
     session({ session, token }) {
       if (token && session.user) {
         session.user.id = token.id as string;
+        // Add numeric ID to session for API calls
+        (session.user as { numericId?: number }).numericId = token.numericId as number;
       }
       return session;
     },


### PR DESCRIPTION
## Summary
- Each authenticated GitHub user now gets their own separate workspace
- Previously all users shared the same hardcoded `userId=1`
- Guest users (not logged in) continue to use userId=1 as a fallback
- Numeric userId is generated consistently from OAuth provider ID using hash function

## Changes
- **auth.ts**: Generate consistent numeric userId from OAuth provider ID
- **chat-layout.tsx**: Add userId/isAuthenticated to ChatContext
- **server-bar.tsx**: Accept and use dynamic userId prop
- **add-workspace-modal.tsx**: Accept and use dynamic userId prop  
- **chat-sidebar.tsx**: Use userId from context for getTasks and getFileTree
- **file-viewer.tsx**: Use userId from context for file operations
- **folders-tab.tsx**: Use userId from context for saveFileContent
- **repos/page.tsx**: Use userId from session for all repository operations

## Test plan
- [ ] Login with GitHub and verify workspaces are user-specific
- [ ] Create a repository while logged in
- [ ] Logout and verify guest user sees different (guest) workspaces
- [ ] Login with different GitHub account and verify separate workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)