### PR TITLE
feat: GitHub authentication with OAuth and PAT support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,9 +52,12 @@ DISCORD_CLIENT_ID=
 # ----------------------------------------------------------------------------
 # GITHUB INTEGRATION (Optional)
 # ----------------------------------------------------------------------------
-# Enables: cloning private repos, creating repos via /new_repo, pushing commits
+# For frontend users: GitHub access is automatic when signing in with GitHub.
+# The frontend's NextAuth handles OAuth and syncs the token to the backend.
 
-# Personal Access Token from: https://github.com/settings/tokens
+# For CLI/bot-only usage (Telegram/Discord without frontend):
+# Create at: https://github.com/settings/tokens -> Generate new token (classic)
+# Required scopes: repo (Full control of private repositories)
 GITHUB_PAT=
 
 # ----------------------------------------------------------------------------

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,23 +1,52 @@
-# Backend API URL (must include https://)
-# Local: http://localhost:5555
-# Production: https://your-backend.up.railway.app
+# ============================================================================
+# Claude Hub Frontend Configuration
+# ============================================================================
+# Copy this file to .env.local and fill in your values.
+# For production: Set these in your hosting platform's environment variables.
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# BACKEND API (Required)
+# ----------------------------------------------------------------------------
+# Local development: http://localhost:5555
+# Production: Your Railway/Docker backend URL (e.g., https://your-app.up.railway.app)
 NEXT_PUBLIC_API_URL=http://localhost:5555
 
-# NextAuth.js - Required for authentication
-# Generate with: openssl rand -base64 32
+# ----------------------------------------------------------------------------
+# AUTHENTICATION (Required for user sign-in)
+# ----------------------------------------------------------------------------
+# Generate a secure secret with: openssl rand -base64 32
+# IMPORTANT: Keep this secret secure and never commit it to git
 AUTH_SECRET=
 
-# GitHub OAuth (optional)
-# Create at: https://github.com/settings/developers
-# Callback URL: {AUTH_URL}/api/auth/callback/github
+# Production callback URL (your deployed frontend URL)
+# Used for OAuth redirects - must match your OAuth app settings exactly
+AUTH_URL=https://your-app.netlify.app
+
+# ----------------------------------------------------------------------------
+# GITHUB OAUTH (Recommended)
+# ----------------------------------------------------------------------------
+# Allows users to sign in with their GitHub account AND automatically grants
+# access to their private repositories. One OAuth app handles both sign-in
+# and repo access - no separate configuration needed on the backend.
+#
+# Setup:
+# 1. Go to https://github.com/settings/developers
+# 2. Click "New OAuth App"
+# 3. Set Homepage URL to your frontend URL
+# 4. Set Authorization callback URL to: {AUTH_URL}/api/auth/callback/github
+# 5. Copy the Client ID and generate a new Client Secret
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
 
-# Google OAuth (optional)
-# Create at: https://console.cloud.google.com/apis/credentials
-# Callback URL: {AUTH_URL}/api/auth/callback/google
+# ----------------------------------------------------------------------------
+# GOOGLE OAUTH (Optional)
+# ----------------------------------------------------------------------------
+# Allows users to sign in with their Google account
+# Setup:
+# 1. Go to https://console.cloud.google.com/apis/credentials
+# 2. Create a new OAuth 2.0 Client ID (Web application)
+# 3. Add your frontend URL to Authorized JavaScript origins
+# 4. Add {AUTH_URL}/api/auth/callback/google to Authorized redirect URIs
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
-
-# Auth URL for production
-AUTH_URL=https://your-app.netlify.app

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useState, useEffect } from "react";
 import Link from "next/link";
-import { signIn } from "next-auth/react";
+import { signIn, useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Github, Sparkles, AlertCircle, Loader2, Shield, GitBranch } from "lucide-react";
@@ -55,10 +55,28 @@ const ERROR_MESSAGES: Record<string, { message: string; suggestion?: string }> =
 };
 
 function LoginContent() {
+  const router = useRouter();
+  const { status } = useSession();
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
   const errorInfo = error ? ERROR_MESSAGES[error] || ERROR_MESSAGES.Default : null;
   const [isLoading, setIsLoading] = useState(false);
+
+  // Redirect authenticated users to home
+  useEffect(() => {
+    if (status === "authenticated") {
+      router.replace("/");
+    }
+  }, [status, router]);
+
+  // Show loading while checking auth or redirecting
+  if (status === "loading" || status === "authenticated") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   const handleGitHubSignIn = async () => {
     setIsLoading(true);

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Github, Sparkles, AlertCircle, Loader2, Shield } from "lucide-react";
+import { Github, Sparkles, AlertCircle, Loader2, Shield, GitBranch } from "lucide-react";
 
 const ERROR_MESSAGES: Record<string, { message: string; suggestion?: string }> = {
   Configuration: {
@@ -123,12 +123,19 @@ function LoginContent() {
           </Button>
 
           {/* Benefits of signing in */}
-          <div className="pt-2 border-t">
+          <div className="pt-2 border-t space-y-3">
             <div className="flex items-start gap-2 text-xs text-muted-foreground">
               <Shield className="w-4 h-4 shrink-0 mt-0.5 text-primary" />
               <div>
                 <span className="font-medium text-foreground">Your data stays private</span>
                 <p className="mt-0.5">Sign in to isolate your workspaces and settings from other users.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 text-xs text-muted-foreground">
+              <GitBranch className="w-4 h-4 shrink-0 mt-0.5 text-primary" />
+              <div>
+                <span className="font-medium text-foreground">Access private repositories</span>
+                <p className="mt-0.5">GitHub sign-in automatically grants access to your private repos.</p>
               </div>
             </div>
           </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -83,9 +83,13 @@ function LoginContent() {
         </CardHeader>
         <CardContent className="space-y-4">
           {errorInfo && (
-            <div className="p-3 text-sm bg-destructive/10 rounded-md border border-destructive/20">
+            <div
+              role="alert"
+              aria-live="polite"
+              className="p-3 text-sm bg-destructive/10 rounded-md border border-destructive/20"
+            >
               <div className="flex items-start gap-2 text-destructive">
-                <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+                <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
                 <div>
                   <span className="font-medium">{errorInfo.message}</span>
                   {errorInfo.suggestion && (

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -61,6 +61,7 @@ function LoginContent() {
   const error = searchParams.get("error");
   const errorInfo = error ? ERROR_MESSAGES[error] || ERROR_MESSAGES.Default : null;
   const [isLoading, setIsLoading] = useState(false);
+  const [signInError, setSignInError] = useState<string | null>(null);
 
   // Redirect authenticated users to home
   useEffect(() => {
@@ -80,12 +81,17 @@ function LoginContent() {
 
   const handleGitHubSignIn = async () => {
     setIsLoading(true);
+    setSignInError(null);
     try {
       await signIn("github", { callbackUrl: "/" });
     } catch {
+      setSignInError("Unable to connect. Please check your internet connection and try again.");
       setIsLoading(false);
     }
   };
+
+  // Combined error display - URL error takes precedence
+  const displayError = errorInfo || (signInError ? { message: signInError } : null);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
@@ -100,7 +106,7 @@ function LoginContent() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {errorInfo && (
+          {displayError && (
             <div
               role="alert"
               aria-live="polite"
@@ -109,9 +115,9 @@ function LoginContent() {
               <div className="flex items-start gap-2 text-destructive">
                 <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
                 <div>
-                  <span className="font-medium">{errorInfo.message}</span>
-                  {errorInfo.suggestion && (
-                    <p className="text-muted-foreground mt-1 text-xs">{errorInfo.suggestion}</p>
+                  <span className="font-medium">{displayError.message}</span>
+                  {displayError.suggestion && (
+                    <p className="text-muted-foreground mt-1 text-xs">{displayError.suggestion}</p>
                   )}
                 </div>
               </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,31 +1,73 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import Link from "next/link";
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Github, Sparkles, AlertCircle } from "lucide-react";
+import { Github, Sparkles, AlertCircle, Loader2, Shield } from "lucide-react";
 
-const ERROR_MESSAGES: Record<string, string> = {
-  Configuration: "There is a problem with the server configuration.",
-  AccessDenied: "Access was denied. You may not have permission to sign in.",
-  Verification: "The verification token has expired or has already been used.",
-  OAuthSignin: "Error starting the OAuth sign-in flow.",
-  OAuthCallback: "Error handling the OAuth callback.",
-  OAuthCreateAccount: "Could not create OAuth account.",
-  EmailCreateAccount: "Could not create email account.",
-  Callback: "Error in the OAuth callback handler.",
-  OAuthAccountNotLinked: "This email is already linked to another account.",
-  SessionRequired: "Please sign in to access this page.",
-  Default: "An error occurred during sign in.",
+const ERROR_MESSAGES: Record<string, { message: string; suggestion?: string }> = {
+  Configuration: {
+    message: "Authentication is not configured on this server.",
+    suggestion: "Please contact the administrator to set up OAuth credentials."
+  },
+  AccessDenied: {
+    message: "Access was denied.",
+    suggestion: "You may not have permission to sign in with this account."
+  },
+  Verification: {
+    message: "The sign-in link has expired.",
+    suggestion: "Please try signing in again."
+  },
+  OAuthSignin: {
+    message: "Unable to start sign-in process.",
+    suggestion: "Try again or use a different sign-in method."
+  },
+  OAuthCallback: {
+    message: "Sign-in was interrupted.",
+    suggestion: "Please try signing in again. If the problem persists, try a different browser."
+  },
+  OAuthCreateAccount: {
+    message: "Unable to create your account.",
+    suggestion: "Please try again or contact support if the issue continues."
+  },
+  EmailCreateAccount: {
+    message: "Unable to create account with this email.",
+    suggestion: "Please try a different sign-in method."
+  },
+  Callback: {
+    message: "Sign-in callback failed.",
+    suggestion: "Please try again. Make sure pop-ups are not blocked."
+  },
+  OAuthAccountNotLinked: {
+    message: "This email is linked to a different sign-in method.",
+    suggestion: "Try signing in with the method you originally used."
+  },
+  SessionRequired: {
+    message: "Sign-in required to access this page.",
+  },
+  Default: {
+    message: "An error occurred during sign-in.",
+    suggestion: "Please try again or use a different sign-in method."
+  },
 };
 
 function LoginContent() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
-  const errorMessage = error ? ERROR_MESSAGES[error] || ERROR_MESSAGES.Default : null;
+  const errorInfo = error ? ERROR_MESSAGES[error] || ERROR_MESSAGES.Default : null;
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleGitHubSignIn = async () => {
+    setIsLoading(true);
+    try {
+      await signIn("github", { callbackUrl: "/" });
+    } catch {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
@@ -37,25 +79,36 @@ function LoginContent() {
           <CardTitle className="text-2xl">Welcome to Claude Hub</CardTitle>
           <CardDescription>
             Sign in to sync your settings and access advanced features.
-            <br />
-            <span className="text-xs mt-2 block">Authentication is optional - you can use the app without signing in.</span>
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {errorMessage && (
-            <div className="flex items-center gap-2 p-3 text-sm text-destructive bg-destructive/10 rounded-md">
-              <AlertCircle className="w-4 h-4 shrink-0" />
-              <span>{errorMessage}</span>
+          {errorInfo && (
+            <div className="p-3 text-sm bg-destructive/10 rounded-md border border-destructive/20">
+              <div className="flex items-start gap-2 text-destructive">
+                <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+                <div>
+                  <span className="font-medium">{errorInfo.message}</span>
+                  {errorInfo.suggestion && (
+                    <p className="text-muted-foreground mt-1 text-xs">{errorInfo.suggestion}</p>
+                  )}
+                </div>
+              </div>
             </div>
           )}
           <Button
             variant="outline"
-            className="w-full"
-            onClick={() => signIn("github", { callbackUrl: "/" })}
+            className="w-full h-11"
+            onClick={handleGitHubSignIn}
+            disabled={isLoading}
           >
-            <Github className="w-4 h-4 mr-2" />
-            Continue with GitHub
+            {isLoading ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <Github className="w-4 h-4 mr-2" />
+            )}
+            {isLoading ? "Connecting..." : "Continue with GitHub"}
           </Button>
+
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
               <span className="w-full border-t" />
@@ -64,9 +117,21 @@ function LoginContent() {
               <span className="bg-background px-2 text-muted-foreground">Or</span>
             </div>
           </div>
-          <Button variant="ghost" className="w-full" asChild>
+
+          <Button variant="ghost" className="w-full" asChild disabled={isLoading}>
             <Link href="/">Continue without signing in</Link>
           </Button>
+
+          {/* Benefits of signing in */}
+          <div className="pt-2 border-t">
+            <div className="flex items-start gap-2 text-xs text-muted-foreground">
+              <Shield className="w-4 h-4 shrink-0 mt-0.5 text-primary" />
+              <div>
+                <span className="font-medium text-foreground">Your data stays private</span>
+                <p className="mt-0.5">Sign in to isolate your workspaces and settings from other users.</p>
+              </div>
+            </div>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/auth/user-menu.tsx
+++ b/frontend/src/components/auth/user-menu.tsx
@@ -40,7 +40,11 @@ export function UserMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-8 w-8 rounded-full">
+        <Button
+          variant="ghost"
+          className="relative h-8 w-8 rounded-full"
+          aria-label={`User menu for ${session.user?.name || "user"}`}
+        >
           <Avatar className="h-8 w-8">
             <AvatarImage src={session.user?.image || ""} alt={session.user?.name || ""} />
             <AvatarFallback>{initials}</AvatarFallback>

--- a/frontend/src/components/chat/add-workspace-modal.tsx
+++ b/frontend/src/components/chat/add-workspace-modal.tsx
@@ -197,14 +197,16 @@ export function AddWorkspaceModal({
             </button>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Repository *</label>
+              <label htmlFor="clone-repo-url" className="text-sm font-medium">Repository *</label>
               <Input
+                id="clone-repo-url"
                 placeholder="user/repo"
                 value={gitUrl}
                 onChange={(e) => setGitUrl(e.target.value)}
                 disabled={isLoading}
+                aria-describedby="clone-repo-hint"
               />
-              <p className="text-xs text-muted-foreground">
+              <p id="clone-repo-hint" className="text-xs text-muted-foreground">
                 Enter <code className="px-1 py-0.5 rounded bg-secondary">user/repo</code> or full URL
               </p>
             </div>
@@ -221,10 +223,11 @@ export function AddWorkspaceModal({
             )}
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">
+              <label htmlFor="clone-repo-name" className="text-sm font-medium">
                 Name <span className="text-muted-foreground">(optional)</span>
               </label>
               <Input
+                id="clone-repo-name"
                 placeholder="Custom folder name"
                 value={repoName}
                 onChange={(e) => setRepoName(e.target.value)}
@@ -233,10 +236,11 @@ export function AddWorkspaceModal({
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">
+              <label htmlFor="clone-repo-branch" className="text-sm font-medium">
                 Branch <span className="text-muted-foreground">(optional)</span>
               </label>
               <Input
+                id="clone-repo-branch"
                 placeholder="main"
                 value={branch}
                 onChange={(e) => setBranch(e.target.value)}
@@ -245,7 +249,7 @@ export function AddWorkspaceModal({
             </div>
 
             {error && (
-              <p className="text-sm text-destructive">{error}</p>
+              <p role="alert" aria-live="polite" className="text-sm text-destructive">{error}</p>
             )}
 
             <Button
@@ -276,8 +280,9 @@ export function AddWorkspaceModal({
             </button>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium">Repository Name *</label>
+              <label htmlFor="create-repo-name" className="text-sm font-medium">Repository Name *</label>
               <Input
+                id="create-repo-name"
                 placeholder="my-new-project"
                 value={repoName}
                 onChange={(e) => setRepoName(e.target.value)}
@@ -339,7 +344,7 @@ export function AddWorkspaceModal({
             </div>
 
             {error && (
-              <p className="text-sm text-destructive">{error}</p>
+              <p role="alert" aria-live="polite" className="text-sm text-destructive">{error}</p>
             )}
 
             <Button

--- a/frontend/src/components/chat/add-workspace-modal.tsx
+++ b/frontend/src/components/chat/add-workspace-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -10,8 +10,8 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { GitBranch, Loader2, ArrowLeft, Github, Lock, Globe } from "lucide-react";
-import { api } from "@/lib/api";
+import { GitBranch, Loader2, ArrowLeft, Github, Lock, Globe, Info } from "lucide-react";
+import { api, type GitHubAuthStatus } from "@/lib/api";
 
 type Mode = "select" | "clone" | "create";
 
@@ -35,6 +35,16 @@ export function AddWorkspaceModal({
   const [isPrivate, setIsPrivate] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [githubStatus, setGithubStatus] = useState<GitHubAuthStatus | null>(null);
+
+  // Fetch GitHub status when modal opens
+  useEffect(() => {
+    if (open) {
+      api.getGitHubStatus(userId)
+        .then(setGithubStatus)
+        .catch(() => setGithubStatus({ hasAuth: false, method: "none", appConfigured: false }));
+    }
+  }, [open, userId]);
 
   const resetState = () => {
     setMode("select");
@@ -83,7 +93,15 @@ export function AddWorkspaceModal({
       onWorkspaceCreated?.(repo.id);
       handleClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to clone repository");
+      const message = err instanceof Error ? err.message : "Failed to clone repository";
+      // Improve error messages for common auth-related failures
+      if (message.includes("Authentication") || message.includes("401") || message.includes("403")) {
+        setError("Authentication required. Connect GitHub in Settings to clone private repositories.");
+      } else if (message.includes("not found") || message.includes("404")) {
+        setError("Repository not found. Check the URL or connect GitHub for private repos.");
+      } else {
+        setError(message);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -106,7 +124,13 @@ export function AddWorkspaceModal({
       onWorkspaceCreated?.(repo.id);
       handleClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create repository");
+      const message = err instanceof Error ? err.message : "Failed to create repository";
+      // Improve error messages for auth-related failures
+      if (message.includes("Authentication") || message.includes("401") || message.includes("403") || message.includes("GitHub")) {
+        setError("GitHub connection required. Connect GitHub in Settings to create repositories.");
+      } else {
+        setError(message);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -185,6 +209,17 @@ export function AddWorkspaceModal({
               </p>
             </div>
 
+            {/* GitHub auth hint for private repos */}
+            {githubStatus && !githubStatus.hasAuth && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-500/10 border border-blue-500/20">
+                <Info className="w-4 h-4 text-blue-500 shrink-0 mt-0.5" />
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-medium text-blue-600 dark:text-blue-400">Private repos?</span>{" "}
+                  Sign in with GitHub or add a Personal Access Token in Settings.
+                </p>
+              </div>
+            )}
+
             <div className="space-y-2">
               <label className="text-sm font-medium">
                 Name <span className="text-muted-foreground">(optional)</span>
@@ -251,12 +286,24 @@ export function AddWorkspaceModal({
             </div>
 
             {/* GitHub Integration Notice */}
-            <div className="flex items-center gap-2 p-3 rounded-lg bg-secondary/50 border border-border">
-              <Github className="w-5 h-5 text-muted-foreground" />
-              <span className="text-sm text-muted-foreground">
-                A GitHub repository will be created automatically
-              </span>
-            </div>
+            {githubStatus?.hasAuth ? (
+              <div className="flex items-center gap-2 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
+                <Github className="w-5 h-5 text-green-500" />
+                <span className="text-sm text-green-600 dark:text-green-400">
+                  Connected as @{githubStatus.login} - repo will be created on your account
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+                <Info className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+                <div className="text-sm">
+                  <span className="font-medium text-amber-600 dark:text-amber-400">GitHub not connected</span>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Sign in with GitHub or add a token in Settings to create repos.
+                  </p>
+                </div>
+              </div>
+            )}
 
             {/* Visibility Toggle */}
             <div className="space-y-2">

--- a/frontend/src/components/chat/add-workspace-modal.tsx
+++ b/frontend/src/components/chat/add-workspace-modal.tsx
@@ -205,6 +205,8 @@ export function AddWorkspaceModal({
                 onChange={(e) => setGitUrl(e.target.value)}
                 disabled={isLoading}
                 aria-describedby="clone-repo-hint"
+                autoComplete="off"
+                spellCheck={false}
               />
               <p id="clone-repo-hint" className="text-xs text-muted-foreground">
                 Enter <code className="px-1 py-0.5 rounded bg-secondary">user/repo</code> or full URL

--- a/frontend/src/components/chat/chat-layout.tsx
+++ b/frontend/src/components/chat/chat-layout.tsx
@@ -304,6 +304,30 @@ export function ChatLayout({ children }: ChatLayoutProps) {
     fetchRepository();
   }, [userId, activeWorkspace]);
 
+  // Sync GitHub token from NextAuth session to backend (consolidated OAuth)
+  useEffect(() => {
+    const user = session?.user as { provider?: string; githubAccessToken?: string; name?: string } | undefined;
+    if (!isAuthenticated || !user?.githubAccessToken || user?.provider !== "github") {
+      return;
+    }
+
+    // Check if we've already synced this session
+    const syncKey = `github_synced_${userId}`;
+    if (sessionStorage.getItem(syncKey)) {
+      return;
+    }
+
+    // Sync the token to the backend
+    api.syncGitHubToken(userId, user.githubAccessToken, user.name || undefined)
+      .then(() => {
+        sessionStorage.setItem(syncKey, "true");
+        console.log("GitHub token synced to backend");
+      })
+      .catch((error) => {
+        console.error("Failed to sync GitHub token:", error);
+      });
+  }, [isAuthenticated, session, userId]);
+
   return (
     <ChatContext.Provider
       value={{

--- a/frontend/src/components/chat/settings-view.tsx
+++ b/frontend/src/components/chat/settings-view.tsx
@@ -2,13 +2,14 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Bot, Server, Puzzle, ChevronRight, Settings2, X } from "lucide-react";
+import { Bot, Server, Puzzle, ChevronRight, Settings2, X, Github } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   AIProviderSettings,
   McpServerSettings,
   PluginSettings,
   GeneralSettings,
+  GitHubSettings,
 } from "./settings";
 
 interface SettingsViewProps {
@@ -20,6 +21,7 @@ export function SettingsView({ onClose }: SettingsViewProps) {
 
   const sections = [
     { id: "ai", name: "AI Provider", icon: Bot },
+    { id: "github", name: "GitHub", icon: Github },
     { id: "mcp", name: "MCP Servers", icon: Server },
     { id: "plugins", name: "Plugins", icon: Puzzle },
     { id: "general", name: "General", icon: Settings2 },
@@ -70,6 +72,7 @@ export function SettingsView({ onClose }: SettingsViewProps) {
         <div className="flex-1 min-h-0 overflow-y-auto">
           <div className="p-6 max-w-3xl">
             {activeSection === "ai" && <AIProviderSettings />}
+            {activeSection === "github" && <GitHubSettings />}
             {activeSection === "mcp" && <McpServerSettings />}
             {activeSection === "plugins" && <PluginSettings />}
             {activeSection === "general" && <GeneralSettings />}

--- a/frontend/src/components/chat/settings-view.tsx
+++ b/frontend/src/components/chat/settings-view.tsx
@@ -40,8 +40,9 @@ export function SettingsView({ onClose }: SettingsViewProps) {
           size="icon"
           onClick={onClose}
           className="w-8 h-8 text-muted-foreground hover:text-foreground"
+          aria-label="Close settings"
         >
-          <X className="w-4 h-4" />
+          <X className="w-4 h-4" aria-hidden="true" />
         </Button>
       </div>
 

--- a/frontend/src/components/chat/settings/github-settings.tsx
+++ b/frontend/src/components/chat/settings/github-settings.tsx
@@ -163,8 +163,12 @@ export function GitHubSettings() {
         <CardContent className="space-y-4">
           {/* Success message */}
           {successMessage && (
-            <div className="flex items-center gap-2 p-3 text-sm bg-green-500/10 rounded-lg border border-green-500/20 animate-in fade-in duration-200">
-              <Check className="w-4 h-4 text-green-500 shrink-0" />
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex items-center gap-2 p-3 text-sm bg-green-500/10 rounded-lg border border-green-500/20 animate-in fade-in duration-200"
+            >
+              <Check className="w-4 h-4 text-green-500 shrink-0" aria-hidden="true" />
               <span className="text-green-600 dark:text-green-400">{successMessage}</span>
             </div>
           )}
@@ -256,8 +260,12 @@ export function GitHubSettings() {
 
               {/* Error display */}
               {patError && !showPatInput && (
-                <div className="flex items-start gap-2 p-3 text-sm text-destructive bg-destructive/10 rounded-lg border border-destructive/20">
-                  <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="flex items-start gap-2 p-3 text-sm text-destructive bg-destructive/10 rounded-lg border border-destructive/20"
+                >
+                  <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
                   <span>{patError}</span>
                 </div>
               )}
@@ -277,10 +285,11 @@ export function GitHubSettings() {
                   ) : (
                   <div className="space-y-3">
                     <div>
-                      <label className="text-sm font-medium mb-1.5 block">
+                      <label htmlFor="github-pat-input" className="text-sm font-medium mb-1.5 block">
                         Personal Access Token
                       </label>
                       <Input
+                        id="github-pat-input"
                         type="password"
                         value={patInput}
                         onChange={(e) => {
@@ -289,8 +298,9 @@ export function GitHubSettings() {
                         }}
                         placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
                         className="font-mono"
+                        aria-describedby="github-pat-hint"
                       />
-                      <p className="text-xs text-muted-foreground mt-1.5">
+                      <p id="github-pat-hint" className="text-xs text-muted-foreground mt-1.5">
                         Requires <code className="bg-secondary px-1 rounded">repo</code> scope.{" "}
                         <a
                           href="https://github.com/settings/tokens/new?scopes=repo&description=tg-claude"
@@ -304,8 +314,8 @@ export function GitHubSettings() {
                     </div>
 
                     {patError && (
-                      <div className="flex items-center gap-2 text-sm text-destructive">
-                        <AlertCircle className="w-4 h-4" />
+                      <div role="alert" aria-live="polite" className="flex items-center gap-2 text-sm text-destructive">
+                        <AlertCircle className="w-4 h-4" aria-hidden="true" />
                         {patError}
                       </div>
                     )}

--- a/frontend/src/components/chat/settings/github-settings.tsx
+++ b/frontend/src/components/chat/settings/github-settings.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Github, LogOut, Key, Check, AlertCircle, Loader2, ExternalLink } from "lucide-react";
+import { api, type GitHubAuthStatus } from "@/lib/api";
+import { useChatContext } from "../chat-layout";
+
+export function GitHubSettings() {
+  const { userId } = useChatContext();
+  const [status, setStatus] = useState<GitHubAuthStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [patInput, setPatInput] = useState("");
+  const [patError, setPatError] = useState<string | null>(null);
+  const [patLoading, setPatLoading] = useState(false);
+  const [showPatInput, setShowPatInput] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const result = await api.getGitHubStatus(userId);
+      setStatus(result);
+    } catch (error) {
+      console.error("Failed to fetch GitHub status:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Handle OAuth callback from URL params
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get("code");
+    const state = urlParams.get("state");
+
+    if (code && state?.startsWith(`${userId}_`)) {
+      // Clear URL params
+      window.history.replaceState({}, "", window.location.pathname);
+
+      // Complete OAuth flow
+      setConnecting(true);
+      api.completeGitHubOAuth(userId, code, state)
+        .then(() => {
+          fetchStatus();
+        })
+        .catch((error) => {
+          console.error("OAuth callback failed:", error);
+          setPatError("Failed to complete GitHub connection");
+        })
+        .finally(() => {
+          setConnecting(false);
+        });
+    }
+  }, [userId, fetchStatus]);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    setPatError(null);
+
+    try {
+      const redirectUri = window.location.origin + window.location.pathname;
+      const { url } = await api.getGitHubOAuthUrl(userId, redirectUri);
+      window.location.href = url;
+    } catch (error) {
+      console.error("Failed to get OAuth URL:", error);
+      setPatError("Failed to initiate GitHub connection. GitHub App may not be configured.");
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await api.disconnectGitHub(userId);
+      await fetchStatus();
+    } catch (error) {
+      console.error("Failed to disconnect:", error);
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const handleSetPat = async () => {
+    if (!patInput.trim()) return;
+
+    setPatLoading(true);
+    setPatError(null);
+
+    try {
+      await api.setGitHubPat(userId, patInput.trim());
+      setPatInput("");
+      setShowPatInput(false);
+      await fetchStatus();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to set PAT";
+      setPatError(message);
+    } finally {
+      setPatLoading(false);
+    }
+  };
+
+  const handleClearPat = async () => {
+    setPatLoading(true);
+    try {
+      await api.clearGitHubPat(userId);
+      await fetchStatus();
+    } catch (error) {
+      console.error("Failed to clear PAT:", error);
+    } finally {
+      setPatLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold">GitHub</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Connect your GitHub account for private repository access
+          </p>
+        </div>
+        <Card>
+          <CardContent className="py-8">
+            <div className="flex items-center justify-center">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">GitHub</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Connect your GitHub account for private repository access
+        </p>
+      </div>
+
+      {/* Connection Status */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Github className="w-5 h-5" />
+            Connection Status
+          </CardTitle>
+          <CardDescription>
+            {status?.hasAuth
+              ? `Connected ${status.method === "app" ? "via GitHub App" : "with Personal Access Token"}`
+              : "Not connected to GitHub"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {status?.hasAuth ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-3 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
+                <Check className="w-5 h-5 text-green-500" />
+                <div className="flex-1">
+                  <p className="font-medium text-green-600 dark:text-green-400">
+                    Connected as @{status.login}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {status.method === "app"
+                      ? "Using GitHub App OAuth (recommended)"
+                      : "Using Personal Access Token"}
+                  </p>
+                </div>
+              </div>
+
+              {status.method === "app" && (
+                <Button
+                  variant="outline"
+                  onClick={handleDisconnect}
+                  disabled={disconnecting}
+                  className="text-destructive hover:text-destructive"
+                >
+                  {disconnecting ? (
+                    <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+                  ) : (
+                    <LogOut className="w-4 h-4 mr-1.5" />
+                  )}
+                  Disconnect GitHub
+                </Button>
+              )}
+
+              {status.method === "pat" && (
+                <Button
+                  variant="outline"
+                  onClick={handleClearPat}
+                  disabled={patLoading}
+                  className="text-destructive hover:text-destructive"
+                >
+                  {patLoading ? (
+                    <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+                  ) : (
+                    <Key className="w-4 h-4 mr-1.5" />
+                  )}
+                  Remove PAT
+                </Button>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* GitHub App OAuth (Primary) */}
+              {status?.appConfigured && (
+                <div className="space-y-3">
+                  <Button
+                    onClick={handleConnect}
+                    disabled={connecting}
+                    className="w-full"
+                  >
+                    {connecting ? (
+                      <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+                    ) : (
+                      <Github className="w-4 h-4 mr-1.5" />
+                    )}
+                    Connect with GitHub
+                  </Button>
+                  <p className="text-xs text-muted-foreground text-center">
+                    Recommended: Securely connect via OAuth
+                  </p>
+                </div>
+              )}
+
+              {/* PAT Fallback */}
+              <div className="border-t border-border pt-4">
+                {!showPatInput ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => setShowPatInput(true)}
+                    className="w-full"
+                  >
+                    <Key className="w-4 h-4 mr-1.5" />
+                    Use Personal Access Token
+                  </Button>
+                ) : (
+                  <div className="space-y-3">
+                    <div>
+                      <label className="text-sm font-medium mb-1.5 block">
+                        Personal Access Token
+                      </label>
+                      <Input
+                        type="password"
+                        value={patInput}
+                        onChange={(e) => {
+                          setPatInput(e.target.value);
+                          setPatError(null);
+                        }}
+                        placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                        className="font-mono"
+                      />
+                      <p className="text-xs text-muted-foreground mt-1.5">
+                        Requires <code className="bg-secondary px-1 rounded">repo</code> scope.{" "}
+                        <a
+                          href="https://github.com/settings/tokens/new?scopes=repo&description=tg-claude"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline inline-flex items-center gap-0.5"
+                        >
+                          Create token <ExternalLink className="w-3 h-3" />
+                        </a>
+                      </p>
+                    </div>
+
+                    {patError && (
+                      <div className="flex items-center gap-2 text-sm text-destructive">
+                        <AlertCircle className="w-4 h-4" />
+                        {patError}
+                      </div>
+                    )}
+
+                    <div className="flex gap-2">
+                      <Button
+                        onClick={handleSetPat}
+                        disabled={!patInput.trim() || patLoading}
+                      >
+                        {patLoading ? (
+                          <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+                        ) : (
+                          <Check className="w-4 h-4 mr-1.5" />
+                        )}
+                        Save Token
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        onClick={() => {
+                          setShowPatInput(false);
+                          setPatInput("");
+                          setPatError(null);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Info Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">About GitHub Integration</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
+          <p>
+            Connecting your GitHub account allows you to:
+          </p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Clone and work with private repositories</li>
+            <li>Push changes to GitHub</li>
+            <li>Create new repositories on GitHub</li>
+          </ul>
+          <p className="pt-2">
+            <strong>OAuth (Recommended):</strong> More secure, easier token management,
+            and can be revoked from GitHub settings.
+          </p>
+          <p>
+            <strong>Personal Access Token:</strong> Alternative for advanced users or
+            if OAuth is not available.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/settings/github-settings.tsx
+++ b/frontend/src/components/chat/settings/github-settings.tsx
@@ -299,6 +299,8 @@ export function GitHubSettings() {
                         placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
                         className="font-mono"
                         aria-describedby="github-pat-hint"
+                        autoComplete="off"
+                        spellCheck={false}
                       />
                       <p id="github-pat-hint" className="text-xs text-muted-foreground mt-1.5">
                         Requires <code className="bg-secondary px-1 rounded">repo</code> scope.{" "}

--- a/frontend/src/components/chat/settings/github-settings.tsx
+++ b/frontend/src/components/chat/settings/github-settings.tsx
@@ -1,30 +1,44 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Github, LogOut, Key, Check, AlertCircle, Loader2, ExternalLink } from "lucide-react";
+import { Github, LogOut, Key, Check, AlertCircle, Loader2, ExternalLink, Info, UserCheck } from "lucide-react";
 import { api, type GitHubAuthStatus } from "@/lib/api";
 import { useChatContext } from "../chat-layout";
 
 export function GitHubSettings() {
-  const { userId } = useChatContext();
+  const { userId, isAuthenticated } = useChatContext();
+  const { data: session } = useSession();
   const [status, setStatus] = useState<GitHubAuthStatus | null>(null);
   const [loading, setLoading] = useState(true);
-  const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [patInput, setPatInput] = useState("");
   const [patError, setPatError] = useState<string | null>(null);
   const [patLoading, setPatLoading] = useState(false);
   const [showPatInput, setShowPatInput] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Check if user signed in with GitHub (has automatic repo access)
+  const sessionUser = session?.user as { provider?: string; name?: string } | undefined;
+  const isGitHubSignIn = isAuthenticated && sessionUser?.provider === "github";
 
   const fetchStatus = useCallback(async () => {
     try {
       const result = await api.getGitHubStatus(userId);
       setStatus(result);
+      setPatError(null);
     } catch (error) {
       console.error("Failed to fetch GitHub status:", error);
+      // Set a default status on error so the UI doesn't break
+      setStatus({ hasAuth: false, method: "none", appConfigured: false });
+      // Only show error if it's a network issue, not just an empty response
+      const message = error instanceof Error ? error.message : "";
+      if (message.includes("fetch") || message.includes("network") || message.includes("ECONNREFUSED")) {
+        setPatError("Unable to connect to the server. Please check your connection and try again.");
+      }
     } finally {
       setLoading(false);
     }
@@ -34,54 +48,17 @@ export function GitHubSettings() {
     fetchStatus();
   }, [fetchStatus]);
 
-  // Handle OAuth callback from URL params
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const code = urlParams.get("code");
-    const state = urlParams.get("state");
-
-    if (code && state?.startsWith(`${userId}_`)) {
-      // Clear URL params
-      window.history.replaceState({}, "", window.location.pathname);
-
-      // Complete OAuth flow
-      setConnecting(true);
-      api.completeGitHubOAuth(userId, code, state)
-        .then(() => {
-          fetchStatus();
-        })
-        .catch((error) => {
-          console.error("OAuth callback failed:", error);
-          setPatError("Failed to complete GitHub connection");
-        })
-        .finally(() => {
-          setConnecting(false);
-        });
-    }
-  }, [userId, fetchStatus]);
-
-  const handleConnect = async () => {
-    setConnecting(true);
-    setPatError(null);
-
-    try {
-      const redirectUri = window.location.origin + window.location.pathname;
-      const { url } = await api.getGitHubOAuthUrl(userId, redirectUri);
-      window.location.href = url;
-    } catch (error) {
-      console.error("Failed to get OAuth URL:", error);
-      setPatError("Failed to initiate GitHub connection. GitHub App may not be configured.");
-      setConnecting(false);
-    }
-  };
-
   const handleDisconnect = async () => {
     setDisconnecting(true);
+    setPatError(null);
     try {
       await api.disconnectGitHub(userId);
+      setSuccessMessage("GitHub disconnected successfully.");
       await fetchStatus();
+      setTimeout(() => setSuccessMessage(null), 5000);
     } catch (error) {
       console.error("Failed to disconnect:", error);
+      setPatError("Failed to disconnect. Please try again.");
     } finally {
       setDisconnecting(false);
     }
@@ -90,17 +67,36 @@ export function GitHubSettings() {
   const handleSetPat = async () => {
     if (!patInput.trim()) return;
 
+    const token = patInput.trim();
+
+    // Validate token format
+    if (!token.startsWith("ghp_") && !token.startsWith("github_pat_")) {
+      setPatError("Invalid token format. GitHub tokens start with 'ghp_' or 'github_pat_'.");
+      return;
+    }
+
     setPatLoading(true);
     setPatError(null);
 
     try {
-      await api.setGitHubPat(userId, patInput.trim());
+      await api.setGitHubPat(userId, token);
       setPatInput("");
       setShowPatInput(false);
+      setSuccessMessage("Personal Access Token saved successfully!");
       await fetchStatus();
+      // Clear success message after 5 seconds
+      setTimeout(() => setSuccessMessage(null), 5000);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to set PAT";
-      setPatError(message);
+      const message = error instanceof Error ? error.message : "";
+      if (message.includes("Invalid PAT") || message.includes("401")) {
+        setPatError("This token is invalid or has been revoked. Please generate a new token.");
+      } else if (message.includes("missing required scopes") || message.includes("repo")) {
+        setPatError("This token needs the 'repo' scope. Please create a new token with repository access.");
+      } else if (message.includes("rate limit")) {
+        setPatError("GitHub rate limit exceeded. Please wait a moment and try again.");
+      } else {
+        setPatError(message || "Failed to validate token. Please check your token and try again.");
+      }
     } finally {
       setPatLoading(false);
     }
@@ -108,11 +104,15 @@ export function GitHubSettings() {
 
   const handleClearPat = async () => {
     setPatLoading(true);
+    setPatError(null);
     try {
       await api.clearGitHubPat(userId);
+      setSuccessMessage("Personal Access Token removed successfully.");
       await fetchStatus();
+      setTimeout(() => setSuccessMessage(null), 5000);
     } catch (error) {
       console.error("Failed to clear PAT:", error);
+      setPatError("Failed to remove token. Please try again.");
     } finally {
       setPatLoading(false);
     }
@@ -161,6 +161,14 @@ export function GitHubSettings() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {/* Success message */}
+          {successMessage && (
+            <div className="flex items-center gap-2 p-3 text-sm bg-green-500/10 rounded-lg border border-green-500/20 animate-in fade-in duration-200">
+              <Check className="w-4 h-4 text-green-500 shrink-0" />
+              <span className="text-green-600 dark:text-green-400">{successMessage}</span>
+            </div>
+          )}
+
           {status?.hasAuth ? (
             <div className="space-y-4">
               <div className="flex items-center gap-3 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
@@ -170,14 +178,16 @@ export function GitHubSettings() {
                     Connected as @{status.login}
                   </p>
                   <p className="text-sm text-muted-foreground">
-                    {status.method === "app"
-                      ? "Using GitHub App OAuth (recommended)"
+                    {isGitHubSignIn && status.method === "app"
+                      ? "Auto-connected via GitHub sign-in"
+                      : status.method === "app"
+                      ? "Connected via GitHub OAuth"
                       : "Using Personal Access Token"}
                   </p>
                 </div>
               </div>
 
-              {status.method === "app" && (
+              {status.method === "app" && !isGitHubSignIn && (
                 <Button
                   variant="outline"
                   onClick={handleDisconnect}
@@ -211,39 +221,60 @@ export function GitHubSettings() {
             </div>
           ) : (
             <div className="space-y-4">
-              {/* GitHub App OAuth (Primary) */}
-              {status?.appConfigured && (
-                <div className="space-y-3">
-                  <Button
-                    onClick={handleConnect}
-                    disabled={connecting}
-                    className="w-full"
-                  >
-                    {connecting ? (
-                      <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
-                    ) : (
-                      <Github className="w-4 h-4 mr-1.5" />
-                    )}
-                    Connect with GitHub
-                  </Button>
-                  <p className="text-xs text-muted-foreground text-center">
-                    Recommended: Securely connect via OAuth
-                  </p>
+              {/* Auto-connect notice for GitHub sign-in users */}
+              {isGitHubSignIn ? (
+                <div className="flex items-start gap-2 p-3 bg-blue-500/10 rounded-lg border border-blue-500/20">
+                  <UserCheck className="w-4 h-4 text-blue-500 shrink-0 mt-0.5" />
+                  <div className="text-sm">
+                    <p className="font-medium text-blue-600 dark:text-blue-400">Connecting automatically...</p>
+                    <p className="text-muted-foreground mt-1">
+                      Your GitHub account will be connected automatically since you signed in with GitHub.
+                    </p>
+                  </div>
+                </div>
+              ) : !isAuthenticated ? (
+                <div className="flex items-start gap-2 p-3 bg-muted/50 rounded-lg border border-border">
+                  <Info className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                  <div className="text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">Sign in for automatic access</p>
+                    <p className="mt-1">
+                      Sign in with GitHub to automatically connect your account, or use a Personal Access Token below.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-start gap-2 p-3 bg-muted/50 rounded-lg border border-border">
+                  <Info className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                  <div className="text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">GitHub not connected</p>
+                    <p className="mt-1">
+                      You signed in with a different provider. Use a Personal Access Token to connect your GitHub account.
+                    </p>
+                  </div>
                 </div>
               )}
 
-              {/* PAT Fallback */}
-              <div className="border-t border-border pt-4">
-                {!showPatInput ? (
-                  <Button
-                    variant="outline"
-                    onClick={() => setShowPatInput(true)}
-                    className="w-full"
-                  >
-                    <Key className="w-4 h-4 mr-1.5" />
-                    Use Personal Access Token
-                  </Button>
-                ) : (
+              {/* Error display */}
+              {patError && !showPatInput && (
+                <div className="flex items-start gap-2 p-3 text-sm text-destructive bg-destructive/10 rounded-lg border border-destructive/20">
+                  <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+                  <span>{patError}</span>
+                </div>
+              )}
+
+              {/* PAT Fallback - only show for non-GitHub sign-in users */}
+              {!isGitHubSignIn && (
+                <div>
+                  {!showPatInput ? (
+                    <Button
+                      variant="outline"
+                      onClick={() => setShowPatInput(true)}
+                      className="w-full"
+                    >
+                      <Key className="w-4 h-4 mr-1.5" />
+                      Use Personal Access Token
+                    </Button>
+                  ) : (
                   <div className="space-y-3">
                     <div>
                       <label className="text-sm font-medium mb-1.5 block">
@@ -303,8 +334,9 @@ export function GitHubSettings() {
                       </Button>
                     </div>
                   </div>
-                )}
-              </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </CardContent>
@@ -315,7 +347,7 @@ export function GitHubSettings() {
         <CardHeader>
           <CardTitle className="text-base">About GitHub Integration</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
           <p>
             Connecting your GitHub account allows you to:
           </p>
@@ -324,14 +356,45 @@ export function GitHubSettings() {
             <li>Push changes to GitHub</li>
             <li>Create new repositories on GitHub</li>
           </ul>
-          <p className="pt-2">
-            <strong>OAuth (Recommended):</strong> More secure, easier token management,
-            and can be revoked from GitHub settings.
-          </p>
-          <p>
-            <strong>Personal Access Token:</strong> Alternative for advanced users or
-            if OAuth is not available.
-          </p>
+
+          <div className="space-y-2 pt-2 border-t">
+            <p>
+              <strong className="text-foreground">Sign in with GitHub (Recommended):</strong> Automatically connects
+              your GitHub account for repository access. No extra setup required.
+            </p>
+            <p>
+              <strong className="text-foreground">Personal Access Token:</strong> Alternative for users who sign in
+              with Google or prefer manual token management.
+            </p>
+          </div>
+
+          {/* Helpful links */}
+          <div className="flex flex-wrap gap-3 pt-2 border-t text-xs">
+            <a
+              href="https://github.com/settings/tokens"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline inline-flex items-center gap-1"
+            >
+              Manage tokens <ExternalLink className="w-3 h-3" />
+            </a>
+            <a
+              href="https://github.com/settings/applications"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline inline-flex items-center gap-1"
+            >
+              Connected apps <ExternalLink className="w-3 h-3" />
+            </a>
+            <a
+              href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline inline-flex items-center gap-1"
+            >
+              Learn more <ExternalLink className="w-3 h-3" />
+            </a>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/chat/settings/index.tsx
+++ b/frontend/src/components/chat/settings/index.tsx
@@ -2,3 +2,4 @@ export { AIProviderSettings } from "./ai-provider-settings";
 export { McpServerSettings } from "./mcp-server-settings";
 export { PluginSettings } from "./plugin-settings";
 export { GeneralSettings } from "./general-settings";
+export { GitHubSettings } from "./github-settings";

--- a/frontend/src/components/chat/sidebar/user-panel.tsx
+++ b/frontend/src/components/chat/sidebar/user-panel.tsx
@@ -1,15 +1,26 @@
 "use client";
 
+import { useState } from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { LogIn, LogOut } from "lucide-react";
+import { LogIn, LogOut, Loader2 } from "lucide-react";
 
 export function UserPanel() {
   const { data: session, status } = useSession();
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   const isLoading = status === "loading";
   const isAuthenticated = status === "authenticated" && session?.user;
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true);
+    await signOut({ callbackUrl: "/" });
+  };
+
+  const handleSignIn = () => {
+    signIn(undefined, { callbackUrl: "/" });
+  };
 
   // Get user initials for avatar
   const getInitials = (name?: string | null) => {
@@ -62,13 +73,20 @@ export function UserPanel() {
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => signOut()}
+                onClick={handleSignOut}
+                disabled={isSigningOut}
                 className="w-8 h-8 text-muted-foreground hover:text-foreground hover:bg-secondary"
               >
-                <LogOut className="w-4 h-4" />
+                {isSigningOut ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <LogOut className="w-4 h-4" />
+                )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="top" className="text-xs">Sign Out</TooltipContent>
+            <TooltipContent side="top" className="text-xs">
+              {isSigningOut ? "Signing out..." : "Sign Out"}
+            </TooltipContent>
           </Tooltip>
         </>
       ) : (
@@ -93,7 +111,7 @@ export function UserPanel() {
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => signIn()}
+                onClick={handleSignIn}
                 className="w-8 h-8 text-muted-foreground hover:text-primary hover:bg-secondary"
               >
                 <LogIn className="w-4 h-4" />

--- a/frontend/src/components/chat/sidebar/user-panel.tsx
+++ b/frontend/src/components/chat/sidebar/user-panel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { LogIn, LogOut, Loader2 } from "lucide-react";
+import { LogIn, LogOut, Loader2, Github } from "lucide-react";
 
 export function UserPanel() {
   const { data: session, status } = useSession();
@@ -12,6 +12,7 @@ export function UserPanel() {
 
   const isLoading = status === "loading";
   const isAuthenticated = status === "authenticated" && session?.user;
+  const provider = (session?.user as { provider?: string })?.provider;
 
   const handleSignOut = async () => {
     setIsSigningOut(true);
@@ -63,7 +64,19 @@ export function UserPanel() {
 
           {/* User Info */}
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{session.user.name || "User"}</p>
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm font-medium truncate">{session.user.name || "User"}</p>
+              {provider === "github" && (
+                <Tooltip delayDuration={0}>
+                  <TooltipTrigger asChild>
+                    <Github className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    Signed in with GitHub (repos connected)
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
             <p className="text-[11px] text-muted-foreground truncate">{session.user.email}</p>
           </div>
 

--- a/frontend/src/components/chat/sidebar/user-panel.tsx
+++ b/frontend/src/components/chat/sidebar/user-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -49,10 +50,12 @@ export function UserPanel() {
           {/* User Avatar */}
           <div className="relative">
             {session.user.image ? (
-              <img
+              <Image
                 src={session.user.image}
                 alt={session.user.name || "User"}
-                className="w-9 h-9 rounded-full object-cover"
+                width={36}
+                height={36}
+                className="rounded-full object-cover"
               />
             ) : (
               <div className="w-9 h-9 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-sm font-semibold">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -120,6 +120,40 @@ export interface FileContent {
   path: string;
 }
 
+export interface GitHubAuthStatus {
+  hasAuth: boolean;
+  method: "app" | "pat" | "none";
+  login?: string;
+  expiresAt?: string;
+  appConfigured: boolean;
+}
+
+export interface GitHubOAuthUrlResponse {
+  url: string;
+  state: string;
+}
+
+export interface GitHubOAuthCallbackResponse {
+  success: boolean;
+  login: string;
+  avatarUrl?: string;
+  method: "app";
+}
+
+export interface GitHubPatResponse {
+  success: boolean;
+  login: string;
+  scopes: string[];
+  method: "pat";
+}
+
+export interface GitHubPatValidation {
+  valid: boolean;
+  login?: string;
+  scopes?: string[];
+  error?: string;
+}
+
 export interface GitCommit {
   sha: string;
   shortSha: string;
@@ -338,6 +372,51 @@ class ApiClient {
     return this.request<{ success: boolean; pluginId: string; pluginSpec: string }>("/api/plugins/install", {
       method: "POST",
       body: JSON.stringify({ pluginId, registry }),
+    });
+  }
+
+  // GitHub Authentication
+  async getGitHubStatus(userId: number): Promise<GitHubAuthStatus> {
+    return this.request<GitHubAuthStatus>(`/api/github/status?userId=${userId}`);
+  }
+
+  async getGitHubOAuthUrl(userId: number, redirectUri: string): Promise<GitHubOAuthUrlResponse> {
+    return this.request<GitHubOAuthUrlResponse>(
+      `/api/github/oauth/url?userId=${userId}&redirectUri=${encodeURIComponent(redirectUri)}`
+    );
+  }
+
+  async completeGitHubOAuth(userId: number, code: string, state?: string): Promise<GitHubOAuthCallbackResponse> {
+    return this.request<GitHubOAuthCallbackResponse>("/api/github/oauth/callback", {
+      method: "POST",
+      body: JSON.stringify({ userId, code, state }),
+    });
+  }
+
+  async disconnectGitHub(userId: number): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>("/api/github/disconnect", {
+      method: "POST",
+      body: JSON.stringify({ userId }),
+    });
+  }
+
+  async setGitHubPat(userId: number, pat: string): Promise<GitHubPatResponse> {
+    return this.request<GitHubPatResponse>("/api/github/pat", {
+      method: "POST",
+      body: JSON.stringify({ userId, pat }),
+    });
+  }
+
+  async clearGitHubPat(userId: number): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>(`/api/github/pat?userId=${userId}`, {
+      method: "DELETE",
+    });
+  }
+
+  async validateGitHubPat(pat: string): Promise<GitHubPatValidation> {
+    return this.request<GitHubPatValidation>("/api/github/pat/validate", {
+      method: "POST",
+      body: JSON.stringify({ pat }),
     });
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -419,6 +419,14 @@ class ApiClient {
       body: JSON.stringify({ pat }),
     });
   }
+
+  // Sync GitHub token from NextAuth session to backend
+  async syncGitHubToken(userId: number, accessToken: string, login?: string): Promise<GitHubPatResponse> {
+    return this.request<GitHubPatResponse>("/api/github/sync", {
+      method: "POST",
+      body: JSON.stringify({ userId, accessToken, login }),
+    });
+  }
 }
 
 export const api = new ApiClient();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -202,7 +202,20 @@ class ApiClient {
     });
 
     if (!response.ok) {
-      throw new Error(`API error: ${response.status} ${response.statusText}`);
+      // Try to extract error message from response body
+      let errorMessage = `API error: ${response.status} ${response.statusText}`;
+      try {
+        const errorBody = await response.json();
+        if (errorBody.error) {
+          errorMessage = errorBody.error;
+          if (errorBody.details) {
+            errorMessage += `: ${errorBody.details}`;
+          }
+        }
+      } catch {
+        // Response body wasn't JSON, use default message
+      }
+      throw new Error(errorMessage);
     }
 
     return response.json();

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -24,6 +24,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.AUTH_GITHUB_SECRET,
+      // Request repo scope for private repository access
+      authorization: {
+        params: {
+          scope: "read:user user:email repo",
+        },
+      },
     }),
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
@@ -44,6 +50,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // Store both the original provider ID and generate a numeric ID
         token.id = user.id;
         token.numericId = generateNumericUserId(`${account.provider}:${user.id}`);
+        token.provider = account.provider;
+        // Store GitHub access token for repo operations
+        if (account.provider === "github" && account.access_token) {
+          token.githubAccessToken = account.access_token;
+        }
       }
       return token;
     },
@@ -52,6 +63,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session.user.id = token.id as string;
         // Add numeric ID to session for API calls
         (session.user as { numericId?: number }).numericId = token.numericId as number;
+        // Add provider info and GitHub token to session
+        (session.user as { provider?: string }).provider = token.provider as string;
+        (session.user as { githubAccessToken?: string }).githubAccessToken = token.githubAccessToken as string | undefined;
       }
       return session;
     },

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5,6 +5,7 @@ import { RepositoryManager } from '../services/RepositoryManager';
 import { UserConfigManager } from '../services/UserConfigManager';
 import { AuditLogger } from '../services/AuditLogger';
 import { gitService } from '../services/GitService';
+import { GitHubAppService } from '../services/GitHubAppService';
 import { logger } from '../utils/logger';
 import { getErrorMessage } from '../utils/errors';
 import { parseSlashCommand } from './slashCommands';
@@ -101,6 +102,7 @@ export function createApiRoutes(
   auditLogger: AuditLogger
 ): Router {
   const router = Router();
+  const githubAppService = new GitHubAppService(userConfigManager);
 
   // Enable CORS for frontend
   router.use((_req, res, next) => {
@@ -758,6 +760,189 @@ export function createApiRoutes(
     } catch (error) {
       logger.error('API: Failed to install plugin', { error: getErrorMessage(error) });
       res.status(500).json({ error: 'Failed to install plugin' });
+    }
+  });
+
+  // ============ GITHUB ============
+
+  // Get GitHub auth status for user
+  router.get('/github/status', async (req: Request, res: Response) => {
+    try {
+      const userId = parseInt(req.query.userId as string, 10);
+
+      if (!userId) {
+        return res.status(400).json({ error: 'Missing userId query parameter' });
+      }
+
+      const status = await userConfigManager.getGitHubAuthStatus(userId);
+      const isConfigured = githubAppService.isConfigured();
+
+      res.json({
+        ...status,
+        appConfigured: isConfigured
+      });
+    } catch (error) {
+      logger.error('API: Failed to get GitHub status', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to get GitHub status' });
+    }
+  });
+
+  // Get GitHub OAuth authorization URL
+  router.get('/github/oauth/url', (req: Request, res: Response) => {
+    try {
+      const userId = parseInt(req.query.userId as string, 10);
+      const redirectUri = req.query.redirectUri as string;
+
+      if (!userId) {
+        return res.status(400).json({ error: 'Missing userId query parameter' });
+      }
+
+      if (!redirectUri) {
+        return res.status(400).json({ error: 'Missing redirectUri query parameter' });
+      }
+
+      if (!githubAppService.isConfigured()) {
+        return res.status(503).json({ error: 'GitHub App not configured on server' });
+      }
+
+      const state = `${userId}_${Date.now()}`;
+      const url = githubAppService.getAuthorizationUrl(userId, redirectUri, state);
+
+      res.json({ url, state });
+    } catch (error) {
+      logger.error('API: Failed to get GitHub OAuth URL', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to get GitHub OAuth URL' });
+    }
+  });
+
+  // Handle GitHub OAuth callback
+  router.post('/github/oauth/callback', async (req: Request, res: Response) => {
+    try {
+      const { code, userId, state } = req.body;
+
+      if (!code || !userId) {
+        return res.status(400).json({ error: 'Missing code or userId' });
+      }
+
+      // Verify state if provided (CSRF protection)
+      if (state) {
+        const expectedPrefix = `${userId}_`;
+        if (!state.startsWith(expectedPrefix)) {
+          return res.status(400).json({ error: 'Invalid state parameter' });
+        }
+      }
+
+      const connection = await githubAppService.completeOAuthFlow(userId, code);
+
+      res.json({
+        success: true,
+        login: connection.login,
+        avatarUrl: connection.avatarUrl,
+        method: 'app'
+      });
+    } catch (error) {
+      logger.error('API: Failed to complete GitHub OAuth', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to complete GitHub OAuth' });
+    }
+  });
+
+  // Disconnect GitHub App
+  router.post('/github/disconnect', async (req: Request, res: Response) => {
+    try {
+      const { userId } = req.body;
+
+      if (!userId) {
+        return res.status(400).json({ error: 'Missing userId' });
+      }
+
+      await githubAppService.disconnect(userId);
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('API: Failed to disconnect GitHub', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to disconnect GitHub' });
+    }
+  });
+
+  // Set GitHub PAT
+  router.post('/github/pat', async (req: Request, res: Response) => {
+    try {
+      const { userId, pat } = req.body;
+
+      if (!userId || !pat) {
+        return res.status(400).json({ error: 'Missing userId or pat' });
+      }
+
+      // Validate the PAT first
+      const validation = await githubAppService.validatePat(pat);
+
+      if (!validation.valid) {
+        return res.status(400).json({
+          error: 'Invalid PAT',
+          details: validation.error
+        });
+      }
+
+      // Check for required scopes
+      const requiredScopes = ['repo'];
+      const hasRequiredScopes = requiredScopes.every(scope =>
+        validation.scopes?.some(s => s === scope || s.startsWith(scope + ':'))
+      );
+
+      if (!hasRequiredScopes) {
+        return res.status(400).json({
+          error: 'PAT missing required scopes',
+          details: `Required: ${requiredScopes.join(', ')}. Found: ${validation.scopes?.join(', ') || 'none'}`
+        });
+      }
+
+      await userConfigManager.setGitHubPat(userId, pat);
+
+      res.json({
+        success: true,
+        login: validation.login,
+        scopes: validation.scopes,
+        method: 'pat'
+      });
+    } catch (error) {
+      logger.error('API: Failed to set GitHub PAT', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to set GitHub PAT' });
+    }
+  });
+
+  // Clear GitHub PAT
+  router.delete('/github/pat', async (req: Request, res: Response) => {
+    try {
+      const userId = parseInt(req.query.userId as string, 10);
+
+      if (!userId) {
+        return res.status(400).json({ error: 'Missing userId query parameter' });
+      }
+
+      await userConfigManager.clearGitHubPat(userId);
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('API: Failed to clear GitHub PAT', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to clear GitHub PAT' });
+    }
+  });
+
+  // Validate a GitHub PAT without saving
+  router.post('/github/pat/validate', async (req: Request, res: Response) => {
+    try {
+      const { pat } = req.body;
+
+      if (!pat) {
+        return res.status(400).json({ error: 'Missing pat' });
+      }
+
+      const validation = await githubAppService.validatePat(pat);
+
+      res.json(validation);
+    } catch (error) {
+      logger.error('API: Failed to validate GitHub PAT', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to validate GitHub PAT' });
     }
   });
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -928,6 +928,56 @@ export function createApiRoutes(
     }
   });
 
+  // Sync GitHub token from frontend session (consolidated OAuth flow)
+  router.post('/github/sync', async (req: Request, res: Response) => {
+    try {
+      const { userId, accessToken, login } = req.body;
+
+      if (!userId || !accessToken) {
+        return res.status(400).json({ error: 'Missing userId or accessToken' });
+      }
+
+      // Validate the token works
+      const validation = await githubAppService.validatePat(accessToken);
+
+      if (!validation.valid) {
+        return res.status(400).json({
+          error: 'Invalid token',
+          details: validation.error
+        });
+      }
+
+      // Store as OAuth token (not PAT) with long expiration
+      // GitHub OAuth tokens from NextAuth don't expire unless revoked
+      const connection = {
+        installationId: 0,
+        accessToken,
+        accessTokenExpiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
+        scope: validation.scopes?.join(' ') || 'repo',
+        connectedAt: new Date(),
+        login: validation.login || login || 'unknown',
+        avatarUrl: '',
+      };
+
+      await userConfigManager.setGitHubConnection(userId, connection);
+
+      logger.info('Synced GitHub token from session', {
+        userId,
+        login: validation.login,
+      });
+
+      res.json({
+        success: true,
+        login: validation.login,
+        scopes: validation.scopes,
+        method: 'app'
+      });
+    } catch (error) {
+      logger.error('API: Failed to sync GitHub token', { error: getErrorMessage(error) });
+      res.status(500).json({ error: 'Failed to sync GitHub token' });
+    }
+  });
+
   // Validate a GitHub PAT without saving
   router.post('/github/pat/validate', async (req: Request, res: Response) => {
     try {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -59,6 +59,7 @@ export const config: BotConfig = {
 
 export function validateConfig(): void {
   const errors: string[] = [];
+  const warnings: string[] = [];
 
   // Only require Telegram token if Telegram is enabled
   if (ENABLE_TELEGRAM && !config.telegramToken) {
@@ -70,8 +71,21 @@ export function validateConfig(): void {
     errors.push('TELEGRAM_ALLOWED_USER_IDS must contain at least one user ID when ENABLE_TELEGRAM is true');
   }
 
+  // Helpful info about GitHub auth for CLI/bot usage
+  // Note: Frontend users who sign in with GitHub get automatic repo access via NextAuth
+  if (!config.githubToken) {
+    warnings.push('No GITHUB_PAT configured. CLI/bot users will need to configure their own token. Frontend users can sign in with GitHub for automatic access.');
+  }
+
   if (errors.length > 0) {
     throw new Error(`Configuration errors:\n${errors.join('\n')}`);
+  }
+
+  // Log warnings (don't fail startup)
+  if (warnings.length > 0) {
+    for (const warning of warnings) {
+      console.warn(`\x1b[33m[config warning]\x1b[0m ${warning}`);
+    }
   }
 }
 

--- a/src/services/GitHubAppService.ts
+++ b/src/services/GitHubAppService.ts
@@ -1,0 +1,355 @@
+import { logger } from '../utils/logger';
+import { getErrorMessage } from '../utils/errors';
+import { GitHubAppConnection } from '../types';
+import { UserConfigManager } from './UserConfigManager';
+
+// GitHub App configuration from environment
+const GITHUB_APP_CLIENT_ID = process.env.GITHUB_APP_CLIENT_ID;
+const GITHUB_APP_CLIENT_SECRET = process.env.GITHUB_APP_CLIENT_SECRET;
+
+// GitHub OAuth URLs
+const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GITHUB_API_URL = 'https://api.github.com';
+
+/**
+ * Service for managing GitHub App OAuth flow and installation tokens
+ */
+export class GitHubAppService {
+  private userConfigManager: UserConfigManager;
+
+  constructor(userConfigManager: UserConfigManager) {
+    this.userConfigManager = userConfigManager;
+  }
+
+  /**
+   * Check if GitHub App is configured
+   */
+  isConfigured(): boolean {
+    return !!(GITHUB_APP_CLIENT_ID && GITHUB_APP_CLIENT_SECRET);
+  }
+
+  /**
+   * Generate OAuth authorization URL for a user
+   * @param userId - User ID to associate with the OAuth flow
+   * @param redirectUri - URI to redirect to after authorization
+   * @param state - Optional state parameter for CSRF protection
+   */
+  getAuthorizationUrl(userId: number, redirectUri: string, state?: string): string {
+    if (!GITHUB_APP_CLIENT_ID) {
+      throw new Error('GitHub App client ID not configured');
+    }
+
+    const params = new URLSearchParams({
+      client_id: GITHUB_APP_CLIENT_ID,
+      redirect_uri: redirectUri,
+      scope: 'repo read:user user:email',
+      state: state || `user_${userId}_${Date.now()}`,
+    });
+
+    return `${GITHUB_AUTHORIZE_URL}?${params.toString()}`;
+  }
+
+  /**
+   * Exchange authorization code for access token
+   * @param code - Authorization code from GitHub
+   */
+  async exchangeCodeForToken(code: string): Promise<{
+    accessToken: string;
+    tokenType: string;
+    scope: string;
+    refreshToken?: string;
+    expiresIn?: number;
+  }> {
+    if (!GITHUB_APP_CLIENT_ID || !GITHUB_APP_CLIENT_SECRET) {
+      throw new Error('GitHub App credentials not configured');
+    }
+
+    const response = await fetch(GITHUB_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: GITHUB_APP_CLIENT_ID,
+        client_secret: GITHUB_APP_CLIENT_SECRET,
+        code,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to exchange code: ${response.statusText}`);
+    }
+
+    const data = await response.json() as {
+      access_token?: string;
+      token_type?: string;
+      scope?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (data.error) {
+      throw new Error(data.error_description || data.error);
+    }
+
+    if (!data.access_token) {
+      throw new Error('No access token in response');
+    }
+
+    return {
+      accessToken: data.access_token,
+      tokenType: data.token_type || 'bearer',
+      scope: data.scope || '',
+      refreshToken: data.refresh_token,
+      expiresIn: data.expires_in,
+    };
+  }
+
+  /**
+   * Refresh an expired access token
+   */
+  async refreshAccessToken(refreshToken: string): Promise<{
+    accessToken: string;
+    expiresIn: number;
+    refreshToken?: string;
+  }> {
+    if (!GITHUB_APP_CLIENT_ID || !GITHUB_APP_CLIENT_SECRET) {
+      throw new Error('GitHub App credentials not configured');
+    }
+
+    const response = await fetch(GITHUB_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: GITHUB_APP_CLIENT_ID,
+        client_secret: GITHUB_APP_CLIENT_SECRET,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to refresh token: ${response.statusText}`);
+    }
+
+    const data = await response.json() as {
+      access_token?: string;
+      expires_in?: number;
+      refresh_token?: string;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (data.error) {
+      throw new Error(data.error_description || data.error);
+    }
+
+    if (!data.access_token) {
+      throw new Error('No access token in response');
+    }
+
+    return {
+      accessToken: data.access_token,
+      expiresIn: data.expires_in || 28800, // Default 8 hours
+      refreshToken: data.refresh_token,
+    };
+  }
+
+  /**
+   * Get authenticated user info from GitHub
+   */
+  async getUserInfo(accessToken: string): Promise<{
+    login: string;
+    id: number;
+    avatarUrl: string;
+    name: string | null;
+    email: string | null;
+  }> {
+    const response = await fetch(`${GITHUB_API_URL}/user`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Accept': 'application/vnd.github.v3+json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to get user info: ${response.statusText}`);
+    }
+
+    const data = await response.json() as {
+      login: string;
+      id: number;
+      avatar_url: string;
+      name: string | null;
+      email: string | null;
+    };
+
+    return {
+      login: data.login,
+      id: data.id,
+      avatarUrl: data.avatar_url,
+      name: data.name,
+      email: data.email,
+    };
+  }
+
+  /**
+   * Complete the OAuth flow and save connection to user config
+   */
+  async completeOAuthFlow(
+    userId: number,
+    code: string
+  ): Promise<GitHubAppConnection> {
+    try {
+      // Exchange code for tokens
+      const tokenData = await this.exchangeCodeForToken(code);
+
+      // Get user info
+      const userInfo = await this.getUserInfo(tokenData.accessToken);
+
+      // Calculate expiration time (default 8 hours if not provided)
+      const expiresIn = tokenData.expiresIn || 28800;
+      const expiresAt = new Date(Date.now() + expiresIn * 1000);
+
+      // Create connection object
+      const connection: GitHubAppConnection = {
+        installationId: 0, // Not using installation tokens, using OAuth
+        accessToken: tokenData.accessToken,
+        accessTokenExpiresAt: expiresAt,
+        refreshToken: tokenData.refreshToken,
+        scope: tokenData.scope,
+        connectedAt: new Date(),
+        login: userInfo.login,
+        avatarUrl: userInfo.avatarUrl,
+      };
+
+      // Save to user config
+      await this.userConfigManager.setGitHubConnection(userId, connection);
+
+      logger.info('Completed GitHub OAuth flow', {
+        userId,
+        login: userInfo.login,
+      });
+
+      return connection;
+    } catch (error) {
+      logger.error('Failed to complete GitHub OAuth flow', {
+        userId,
+        error: getErrorMessage(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Ensure user has a valid GitHub token, refreshing if necessary
+   * Returns the valid token or null if unavailable
+   */
+  async ensureValidToken(userId: number): Promise<string | null> {
+    const config = await this.userConfigManager.getConfig(userId);
+
+    // Check GitHub App connection
+    if (config.github?.accessToken) {
+      const bufferMs = 5 * 60 * 1000; // 5 minute buffer
+      const isExpired = new Date(config.github.accessTokenExpiresAt).getTime() < Date.now() + bufferMs;
+
+      if (!isExpired) {
+        return config.github.accessToken;
+      }
+
+      // Try to refresh if we have a refresh token
+      if (config.github.refreshToken) {
+        try {
+          const refreshed = await this.refreshAccessToken(config.github.refreshToken);
+          const newExpiresAt = new Date(Date.now() + refreshed.expiresIn * 1000);
+
+          await this.userConfigManager.updateGitHubAccessToken(
+            userId,
+            refreshed.accessToken,
+            newExpiresAt
+          );
+
+          // Update refresh token if a new one was provided
+          if (refreshed.refreshToken) {
+            const updatedConfig = await this.userConfigManager.getConfig(userId);
+            if (updatedConfig.github) {
+              updatedConfig.github.refreshToken = refreshed.refreshToken;
+              await this.userConfigManager.setGitHubConnection(userId, updatedConfig.github);
+            }
+          }
+
+          logger.info('Refreshed GitHub access token', { userId });
+          return refreshed.accessToken;
+        } catch (error) {
+          logger.warn('Failed to refresh GitHub token', {
+            userId,
+            error: getErrorMessage(error),
+          });
+          // Fall through to PAT
+        }
+      }
+    }
+
+    // Fall back to PAT
+    if (config.githubPat) {
+      return config.githubPat;
+    }
+
+    return null;
+  }
+
+  /**
+   * Disconnect GitHub App connection
+   */
+  async disconnect(userId: number): Promise<void> {
+    await this.userConfigManager.clearGitHubConnection(userId);
+    logger.info('Disconnected GitHub App', { userId });
+  }
+
+  /**
+   * Validate a Personal Access Token
+   */
+  async validatePat(pat: string): Promise<{
+    valid: boolean;
+    login?: string;
+    scopes?: string[];
+    error?: string;
+  }> {
+    try {
+      const response = await fetch(`${GITHUB_API_URL}/user`, {
+        headers: {
+          'Authorization': `Bearer ${pat}`,
+          'Accept': 'application/vnd.github.v3+json',
+        },
+      });
+
+      if (!response.ok) {
+        return {
+          valid: false,
+          error: response.status === 401 ? 'Invalid token' : `GitHub API error: ${response.statusText}`,
+        };
+      }
+
+      const userData = await response.json() as { login: string };
+      const scopes = response.headers.get('x-oauth-scopes')?.split(', ') || [];
+
+      return {
+        valid: true,
+        login: userData.login,
+        scopes,
+      };
+    } catch (error) {
+      return {
+        valid: false,
+        error: getErrorMessage(error),
+      };
+    }
+  }
+}

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -27,17 +27,27 @@ interface PushResult {
 }
 
 class GitService {
-  private githubToken: string | undefined;
+  private defaultGithubToken: string | undefined;
 
   constructor() {
-    this.githubToken = process.env.GITHUB_PAT;
+    this.defaultGithubToken = process.env.GITHUB_PAT;
+  }
+
+  /**
+   * Get the effective token to use (provided token or default)
+   */
+  private getEffectiveToken(token?: string): string | undefined {
+    return token || this.defaultGithubToken;
   }
 
   /**
    * Inject GitHub token into git URL for authentication
+   * @param gitUrl - The git URL to inject token into
+   * @param token - Optional per-user token (falls back to environment variable)
    */
-  injectTokenIntoUrl(gitUrl: string): string {
-    if (!this.githubToken || !gitUrl.includes('github.com')) {
+  injectTokenIntoUrl(gitUrl: string, token?: string): string {
+    const effectiveToken = this.getEffectiveToken(token);
+    if (!effectiveToken || !gitUrl.includes('github.com')) {
       return gitUrl;
     }
 
@@ -57,7 +67,7 @@ class GitService {
     if (url.startsWith('https://github.com/') || url.startsWith('https://www.github.com/')) {
       return url.replace(
         /^https:\/\/(www\.)?github\.com\//,
-        `https://x-access-token:${this.githubToken}@github.com/`
+        `https://x-access-token:${effectiveToken}@github.com/`
       );
     }
 
@@ -203,16 +213,19 @@ class GitService {
 
   /**
    * Ensure GitHub remote uses token auth for non-interactive pushes
+   * @param workingDir - Working directory
+   * @param token - Optional per-user token (falls back to environment variable)
    */
-  async ensureAuthRemote(workingDir: string): Promise<boolean> {
-    if (!this.githubToken) return false;
+  async ensureAuthRemote(workingDir: string, token?: string): Promise<boolean> {
+    const effectiveToken = this.getEffectiveToken(token);
+    if (!effectiveToken) return false;
 
     try {
       const remoteUrl = await this.getRemoteUrl(workingDir);
       if (!remoteUrl || !remoteUrl.includes('github.com')) return false;
       if (remoteUrl.includes('x-access-token:') || remoteUrl.includes('oauth2:')) return false;
 
-      const authUrl = this.injectTokenIntoUrl(remoteUrl);
+      const authUrl = this.injectTokenIntoUrl(remoteUrl, effectiveToken);
       if (authUrl === remoteUrl) return false;
 
       await execAsync(`git remote set-url origin "${authUrl}"`, {
@@ -303,17 +316,20 @@ class GitService {
 
   /**
    * Push to remote
+   * @param workingDir - Working directory
+   * @param token - Optional per-user token (falls back to environment variable)
    */
-  async push(workingDir: string): Promise<PushResult> {
+  async push(workingDir: string, token?: string): Promise<PushResult> {
     try {
       const hasRemote = await this.hasRemote(workingDir);
       if (!hasRemote) {
         return { status: 'no_remote' };
       }
 
+      const effectiveToken = this.getEffectiveToken(token);
       const remoteUrl = await this.getRemoteUrl(workingDir);
-      if (remoteUrl && this.githubToken && remoteUrl.includes('github.com') && !remoteUrl.includes('@github.com')) {
-        const authUrl = this.injectTokenIntoUrl(remoteUrl);
+      if (remoteUrl && effectiveToken && remoteUrl.includes('github.com') && !remoteUrl.includes('@github.com')) {
+        const authUrl = this.injectTokenIntoUrl(remoteUrl, effectiveToken);
         await execAsync(`git remote set-url origin "${authUrl}"`, { cwd: workingDir, timeout: 5000 });
       }
 
@@ -443,9 +459,13 @@ class GitService {
 
   /**
    * Clone repository
+   * @param gitUrl - Git URL to clone
+   * @param targetPath - Target path to clone to
+   * @param branch - Optional branch to checkout
+   * @param token - Optional per-user token (falls back to environment variable)
    */
-  async clone(gitUrl: string, targetPath: string, branch?: string): Promise<void> {
-    const authUrl = this.injectTokenIntoUrl(gitUrl);
+  async clone(gitUrl: string, targetPath: string, branch?: string, token?: string): Promise<void> {
+    const authUrl = this.injectTokenIntoUrl(gitUrl, token);
     const args = ['clone', authUrl, ...(branch ? ['-b', branch] : []), targetPath];
 
     await this.execGit(args);

--- a/src/services/UserConfigManager.ts
+++ b/src/services/UserConfigManager.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { UserConfig } from '../types';
+import { UserConfig, GitHubAppConnection } from '../types';
 import { logger } from '../utils/logger';
 import { CONFIG_PATH } from '../config';
 import { getErrorMessage } from '../utils/errors';
@@ -86,6 +86,12 @@ export class UserConfigManager {
       // Convert date strings back to Date objects
       config.createdAt = new Date(config.createdAt);
       config.updatedAt = new Date(config.updatedAt);
+
+      // Convert GitHubAppConnection date fields
+      if (config.github) {
+        config.github.accessTokenExpiresAt = new Date(config.github.accessTokenExpiresAt);
+        config.github.connectedAt = new Date(config.github.connectedAt);
+      }
 
       this.configs.set(userId, config);
 
@@ -184,6 +190,12 @@ export class UserConfigManager {
     if (updates.enabledPlugins !== undefined) {
       config.enabledPlugins = updates.enabledPlugins;
     }
+    if (updates.githubPat !== undefined) {
+      config.githubPat = updates.githubPat;
+    }
+    if (updates.github !== undefined) {
+      config.github = updates.github;
+    }
 
     config.updatedAt = new Date();
 
@@ -258,5 +270,133 @@ export class UserConfigManager {
    */
   hasConfig(userId: number): boolean {
     return this.configs.has(userId);
+  }
+
+  // ==================== GitHub Credential Methods ====================
+
+  /**
+   * Set GitHub Personal Access Token for a user
+   */
+  async setGitHubPat(userId: number, pat: string): Promise<void> {
+    await this.updateConfig(userId, { githubPat: pat });
+    logger.info('Set GitHub PAT for user', { userId });
+  }
+
+  /**
+   * Clear GitHub Personal Access Token for a user
+   */
+  async clearGitHubPat(userId: number): Promise<void> {
+    const config = await this.getConfig(userId);
+    delete config.githubPat;
+    config.updatedAt = new Date();
+    await this.saveConfig(config);
+    logger.info('Cleared GitHub PAT for user', { userId });
+  }
+
+  /**
+   * Set GitHub App connection for a user
+   */
+  async setGitHubConnection(userId: number, connection: GitHubAppConnection): Promise<void> {
+    await this.updateConfig(userId, { github: connection });
+    logger.info('Set GitHub App connection for user', { userId, login: connection.login });
+  }
+
+  /**
+   * Update GitHub App access token (for token refresh)
+   */
+  async updateGitHubAccessToken(
+    userId: number,
+    accessToken: string,
+    expiresAt: Date
+  ): Promise<void> {
+    const config = await this.getConfig(userId);
+    if (config.github) {
+      config.github.accessToken = accessToken;
+      config.github.accessTokenExpiresAt = expiresAt;
+      config.updatedAt = new Date();
+      await this.saveConfig(config);
+      logger.info('Updated GitHub access token for user', { userId });
+    }
+  }
+
+  /**
+   * Clear GitHub App connection for a user
+   */
+  async clearGitHubConnection(userId: number): Promise<void> {
+    const config = await this.getConfig(userId);
+    delete config.github;
+    config.updatedAt = new Date();
+    await this.saveConfig(config);
+    logger.info('Cleared GitHub App connection for user', { userId });
+  }
+
+  /**
+   * Get the best available GitHub token for a user
+   * Priority: GitHub App token (if valid) > PAT
+   * Returns null if no token available
+   */
+  async getGitHubToken(userId: number): Promise<string | null> {
+    const config = await this.getConfig(userId);
+
+    // Check GitHub App connection first (preferred)
+    if (config.github?.accessToken) {
+      // Check if token is still valid (with 5 min buffer)
+      const bufferMs = 5 * 60 * 1000;
+      const isExpired = new Date(config.github.accessTokenExpiresAt).getTime() < Date.now() + bufferMs;
+
+      if (!isExpired) {
+        return config.github.accessToken;
+      }
+      // Token expired - will need refresh (handled by GitHubAppService)
+      logger.debug('GitHub App token expired, falling back to PAT', { userId });
+    }
+
+    // Fall back to PAT
+    if (config.githubPat) {
+      return config.githubPat;
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if user has any GitHub authentication configured
+   */
+  async hasGitHubAuth(userId: number): Promise<boolean> {
+    const config = await this.getConfig(userId);
+    return !!(config.github?.accessToken || config.githubPat);
+  }
+
+  /**
+   * Get GitHub authentication status for a user
+   */
+  async getGitHubAuthStatus(userId: number): Promise<{
+    hasAuth: boolean;
+    method: 'app' | 'pat' | 'none';
+    login?: string;
+    expiresAt?: Date;
+  }> {
+    const config = await this.getConfig(userId);
+
+    if (config.github?.accessToken) {
+      return {
+        hasAuth: true,
+        method: 'app',
+        login: config.github.login,
+        expiresAt: config.github.accessTokenExpiresAt
+      };
+    }
+
+    if (config.githubPat) {
+      return {
+        hasAuth: true,
+        method: 'pat'
+      };
+    }
+
+    return {
+      hasAuth: false,
+      method: 'none'
+    };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,18 @@ export interface McpConfig {
   mcpServers: Record<string, McpServer>;
 }
 
+// GitHub Integration Types
+export interface GitHubAppConnection {
+  installationId: number;
+  accessToken: string;
+  accessTokenExpiresAt: Date;
+  refreshToken?: string;
+  scope?: string;
+  connectedAt: Date;
+  login?: string; // GitHub username
+  avatarUrl?: string;
+}
+
 export interface UserConfig {
   userId: number;
   currentRepositoryId?: string;
@@ -157,6 +169,9 @@ export interface UserConfig {
   techStack?: TechStackPreferences;
   aiProvider?: AIProviderConfig;
   claudeMdTemplate?: string;
+  // GitHub authentication
+  githubPat?: string;  // Personal Access Token (fallback option)
+  github?: GitHubAppConnection;  // GitHub App OAuth connection (primary)
   mcpConfigs?: Record<string, McpConfig>;
   enabledPlugins?: string[]; // List of enabled plugin IDs (e.g., ['ralph-loop', 'commit-commands'])
   limits?: {


### PR DESCRIPTION
## Summary
- Add GitHub OAuth flow for secure account connection (primary method)
- Add Personal Access Token input as fallback for advanced users
- Implement backend services for token management and validation
- Add GitHub settings section in frontend settings view

## Changes

### Backend
- **GitHubAppService**: New service for OAuth token exchange, refresh, and validation
- **API Endpoints**: 
  - `GET /api/github/status` - Get user's GitHub auth status
  - `GET /api/github/oauth/url` - Generate OAuth authorization URL
  - `POST /api/github/oauth/callback` - Complete OAuth flow
  - `POST /api/github/disconnect` - Disconnect GitHub App
  - `POST /api/github/pat` - Set and validate PAT
  - `DELETE /api/github/pat` - Clear PAT
  - `POST /api/github/pat/validate` - Validate PAT without saving
- **GitService**: Modified to support per-user tokens for clone/push operations
- **UserConfigManager**: Extended with GitHub credential methods
- **Types**: Added `GitHubAppConnection` interface and `githubPat`/`github` fields to `UserConfig`

### Frontend
- **GitHub Settings**: New settings section with OAuth and PAT options
- **API Client**: Added GitHub authentication methods

## Configuration
To enable GitHub OAuth, set these environment variables:
- `GITHUB_APP_CLIENT_ID` - GitHub OAuth App client ID
- `GITHUB_APP_CLIENT_SECRET` - GitHub OAuth App client secret

Without these, only PAT authentication will be available.

## Test Plan
- [ ] Test GitHub OAuth flow with GitHub App credentials
- [ ] Test PAT entry and validation
- [ ] Test PAT removal
- [ ] Test OAuth disconnection
- [ ] Verify token is used for private repo clone/push

🤖 Generated with [Claude Code](https://claude.com/claude-code)