### PR TITLE
fix: improve GitHub repo creation error handling

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -363,14 +363,14 @@ export function createApiRoutes(
             // Create GitHub repository
             const result = await gitService.createGitHubRepository(repo.path, isPrivate === true);
 
-            if (result === 'success') {
+            if (result.status === 'success') {
               // Refresh repository info to get the new gitUrl
               repo = await repositoryManager.refreshRepository(userId, repo.id);
               logger.info('Created GitHub repository', { repoId: repo.id, name: repo.name });
-            } else if (result === 'already_exists') {
+            } else if (result.status === 'already_exists') {
               logger.warn('GitHub repository already exists', { name: repo.name });
             } else {
-              logger.error('Failed to create GitHub repository', { name: repo.name });
+              logger.warn('Failed to create GitHub repository', { name: repo.name, error: result.error });
             }
           } catch (ghError) {
             // Don't fail the whole operation if GitHub creation fails

--- a/src/clients/discord/handlers/ConfigHandlers.ts
+++ b/src/clients/discord/handlers/ConfigHandlers.ts
@@ -141,7 +141,7 @@ export class ConfigHandlers extends BaseHandler {
         name
       );
 
-      if (result === 'success') {
+      if (result.status === 'success') {
         await interaction.reply({
           content: `Created GitHub repo \`${name}\` (${visibility}).`,
           flags: this.ephemeralFlags()
@@ -149,9 +149,14 @@ export class ConfigHandlers extends BaseHandler {
         return;
       }
 
-      const message = result === 'already_exists'
-        ? `Repo \`${name}\` already exists on GitHub.`
-        : `Failed to create GitHub repo \`${name}\`.`;
+      let message: string;
+      if (result.status === 'not_authenticated') {
+        message = result.error || 'GitHub not configured. Set GITHUB_PAT environment variable.';
+      } else if (result.status === 'already_exists') {
+        message = `Repo \`${name}\` already exists on GitHub.`;
+      } else {
+        message = result.error || `Failed to create GitHub repo \`${name}\`.`;
+      }
 
       await interaction.reply({ content: message, flags: this.ephemeralFlags() });
     } catch (error) {

--- a/src/clients/telegram/handlers/BotHandlers.ts
+++ b/src/clients/telegram/handlers/BotHandlers.ts
@@ -109,6 +109,10 @@ export class BotHandlers {
     return this.statusHandlers.handleStatus(msg);
   }
 
+  async handleSystem(msg: Message): Promise<void> {
+    return this.statusHandlers.handleSystem(msg);
+  }
+
   async handleConfig(msg: Message, match: RegExpExecArray | null): Promise<void> {
     return this.configHandlers.handleConfig(msg, match);
   }

--- a/src/clients/telegram/handlers/CallbackQueryHandler.ts
+++ b/src/clients/telegram/handlers/CallbackQueryHandler.ts
@@ -436,7 +436,7 @@ export class CallbackQueryHandler extends BaseHandler {
       const originalName = path.basename(workingDir);
       const result = await gitService.createGitHubRepository(workingDir, isPrivate);
 
-      if (result === 'success') {
+      if (result.status === 'success') {
         const currentRepo = this.repositoryManager.getCurrentRepository(userId);
         if (currentRepo) await this.repositoryManager.refreshRepository(userId, currentRepo.id);
 
@@ -444,13 +444,17 @@ export class CallbackQueryHandler extends BaseHandler {
           `*GitHub Repository Created!*\n\nVisibility: ${isPrivate ? 'Private' : 'Public'}`,
           { inline_keyboard: [[{ text: 'View Repository', callback_data: 'repo_current' }]] }
         );
-      } else if (result === 'already_exists') {
+      } else if (result.status === 'already_exists') {
         stateManager.setPendingRepoCreation(userId, { workingDir, isPrivate, userId, chatId, originalName });
         await this.editMessage(chatId, messageId,
           `*Repository Name Exists*\n\n\`${originalName}\` already exists. Reply with a different name:`
         );
+      } else if (result.status === 'not_authenticated') {
+        await this.editMessage(chatId, messageId,
+          `⚠️ *GitHub Auth Error*\n\n${result.error || 'Set GITHUB_PAT in Railway environment variables.'}`
+        );
       } else {
-        await this.editMessage(chatId, messageId, '*Failed*\n\nCheck gh CLI and GitHub authentication.');
+        await this.editMessage(chatId, messageId, `❌ *Failed*\n\n${result.error || 'Unknown error'}`);
       }
     } catch (error) {
       await this.editMessage(chatId, messageId, `*Error*\n\n${getErrorMessage(error)}`);
@@ -506,7 +510,7 @@ export class CallbackQueryHandler extends BaseHandler {
           );
         } else if (result.status === 'not_authenticated') {
           await this.editMessage(chatId, messageId,
-            `⚠️ *GitHub not configured*\n\nSet \`GITHUB_PAT\` in Railway environment variables to enable GitHub repo creation.`
+            `⚠️ *GitHub Auth Error*\n\n${result.error || 'Set GITHUB_PAT in Railway environment variables.'}`
           );
         } else if (result.status === 'already_exists') {
           await this.editMessage(chatId, messageId, `Repository \`${repo.name}\` already exists on GitHub.`);
@@ -548,7 +552,7 @@ export class CallbackQueryHandler extends BaseHandler {
         );
       } else if (result.status === 'not_authenticated') {
         await this.bot.editMessageText(
-          `⚠️ *GitHub not configured*\n\nSet \`GITHUB_PAT\` in Railway to enable repo creation.`,
+          `⚠️ *GitHub Auth Error*\n\n${result.error || 'Set GITHUB_PAT in Railway environment variables.'}`,
           { chat_id: chatId, message_id: statusMsg.message_id, parse_mode: 'Markdown' }
         );
       } else if (result.status === 'already_exists') {
@@ -1336,7 +1340,7 @@ export class CallbackQueryHandler extends BaseHandler {
       // Create GitHub repository
       const result = await gitService.createGitHubRepository(repo.path, isPrivate);
 
-      if (result === 'success') {
+      if (result.status === 'success') {
         await this.repositoryManager.refreshRepository(userId, repo.id);
         await this.updatePinnedRepositoryInfo(chatId, userId);
 
@@ -1350,13 +1354,19 @@ export class CallbackQueryHandler extends BaseHandler {
           `📂 \`${escapedPath}\``,
           { inline_keyboard: [[{ text: '📂 View', callback_data: 'repo_current' }]] }
         );
-      } else if (result === 'already_exists') {
+      } else if (result.status === 'not_authenticated') {
+        await this.editMessage(chatId, messageId,
+          `⚠️ *GitHub Auth Error*\n\n` +
+          `${result.error || 'Set GITHUB_PAT in Railway environment variables.'}\n\n` +
+          `Local repo created at \`${repo.path}\``
+        );
+      } else if (result.status === 'already_exists') {
         await this.editMessage(chatId, messageId,
           `Repository \`${name}\` already exists on GitHub.\n\nTry a different name with /new_repo`
         );
       } else {
         await this.editMessage(chatId, messageId,
-          `Failed to create GitHub repository.\n\nLocal repo created at \`${repo.path}\``
+          `❌ ${result.error || 'Failed to create GitHub repository.'}\n\nLocal repo created at \`${repo.path}\``
         );
       }
     } catch (error) {

--- a/src/clients/telegram/handlers/CallbackQueryHandler.ts
+++ b/src/clients/telegram/handlers/CallbackQueryHandler.ts
@@ -498,14 +498,20 @@ export class CallbackQueryHandler extends BaseHandler {
 
         const result = await gitService.createGitHubRepository(repo.path, isPrivate);
 
-        if (result === 'success') {
+        if (result.status === 'success') {
           await this.repositoryManager.refreshRepository(userId, repo.id);
           await this.editMessage(chatId, messageId,
             `*GitHub Repository Created!*\n\n\`${repo.name}\` - ${isPrivate ? 'Private' : 'Public'}`,
             { inline_keyboard: [[{ text: 'View Repository', callback_data: 'repo_current' }]] }
           );
+        } else if (result.status === 'not_authenticated') {
+          await this.editMessage(chatId, messageId,
+            `⚠️ *GitHub not configured*\n\nSet \`GITHUB_PAT\` in Railway environment variables to enable GitHub repo creation.`
+          );
+        } else if (result.status === 'already_exists') {
+          await this.editMessage(chatId, messageId, `Repository \`${repo.name}\` already exists on GitHub.`);
         } else {
-          await this.editMessage(chatId, messageId, `Repository \`${repo.name}\` ${result === 'already_exists' ? 'already exists' : 'creation failed'}`);
+          await this.editMessage(chatId, messageId, `❌ Creation failed: ${result.error || 'Unknown error'}`);
         }
       } catch (error) {
         await this.editMessage(chatId, messageId, `Error: ${getErrorMessage(error)}`);
@@ -529,7 +535,7 @@ export class CallbackQueryHandler extends BaseHandler {
     try {
       const result = await gitService.createGitHubRepository(pending.workingDir, pending.isPrivate, newRepoName);
 
-      if (result === 'success') {
+      if (result.status === 'success') {
         const currentRepo = this.repositoryManager.getCurrentRepository(userId);
         if (currentRepo) await this.repositoryManager.refreshRepository(userId, currentRepo.id);
 
@@ -540,8 +546,16 @@ export class CallbackQueryHandler extends BaseHandler {
             reply_markup: { inline_keyboard: [[{ text: 'View Repository', callback_data: 'repo_current' }]] }
           }
         );
+      } else if (result.status === 'not_authenticated') {
+        await this.bot.editMessageText(
+          `⚠️ *GitHub not configured*\n\nSet \`GITHUB_PAT\` in Railway to enable repo creation.`,
+          { chat_id: chatId, message_id: statusMsg.message_id, parse_mode: 'Markdown' }
+        );
+      } else if (result.status === 'already_exists') {
+        await this.bot.editMessageText(`\`${newRepoName}\` already exists. Try /repo again.`,
+          { chat_id: chatId, message_id: statusMsg.message_id, parse_mode: 'Markdown' });
       } else {
-        await this.bot.editMessageText(`\`${newRepoName}\` also exists. Try /repo again.`,
+        await this.bot.editMessageText(`❌ Failed: ${result.error || 'Unknown error'}`,
           { chat_id: chatId, message_id: statusMsg.message_id, parse_mode: 'Markdown' });
       }
     } catch (error) {

--- a/src/clients/telegram/handlers/RepositoryHandlers.ts
+++ b/src/clients/telegram/handlers/RepositoryHandlers.ts
@@ -853,7 +853,7 @@ export class RepositoryHandlers extends BaseHandler {
       // Create GitHub repository
       const result = await gitService.createGitHubRepository(repo.path, isPrivate);
 
-      if (result === 'success') {
+      if (result.status === 'success') {
         await this.repositoryManager.refreshRepository(userId, repo.id);
         await this.updatePinnedRepositoryInfo(chatId, userId);
 
@@ -874,14 +874,21 @@ export class RepositoryHandlers extends BaseHandler {
             }
           }
         );
-      } else if (result === 'already_exists') {
+      } else if (result.status === 'not_authenticated') {
+        await this.bot.editMessageText(
+          `⚠️ *GitHub not configured*\n\n` +
+          `Set \`GITHUB_PAT\` in Railway environment variables.\n\n` +
+          `Local repo created at \`${repo.path}\``,
+          { chat_id: chatId, message_id: messageId, parse_mode: 'Markdown' }
+        );
+      } else if (result.status === 'already_exists') {
         await this.bot.editMessageText(
           `Repository \`${name}\` already exists on GitHub.\n\nTry a different name with /new_repo`,
           { chat_id: chatId, message_id: messageId, parse_mode: 'Markdown' }
         );
       } else {
         await this.bot.editMessageText(
-          `Failed to create GitHub repository.\n\nLocal repo created at \`${repo.path}\``,
+          `❌ GitHub creation failed: ${result.error || 'Unknown error'}\n\nLocal repo at \`${repo.path}\``,
           { chat_id: chatId, message_id: messageId, parse_mode: 'Markdown' }
         );
       }

--- a/src/clients/telegram/handlers/RepositoryHandlers.ts
+++ b/src/clients/telegram/handlers/RepositoryHandlers.ts
@@ -876,8 +876,8 @@ export class RepositoryHandlers extends BaseHandler {
         );
       } else if (result.status === 'not_authenticated') {
         await this.bot.editMessageText(
-          `⚠️ *GitHub not configured*\n\n` +
-          `Set \`GITHUB_PAT\` in Railway environment variables.\n\n` +
+          `⚠️ *GitHub Auth Error*\n\n` +
+          `${result.error || 'Set GITHUB_PAT in Railway environment variables.'}\n\n` +
           `Local repo created at \`${repo.path}\``,
           { chat_id: chatId, message_id: messageId, parse_mode: 'Markdown' }
         );

--- a/src/clients/telegram/handlers/StatusHandlers.ts
+++ b/src/clients/telegram/handlers/StatusHandlers.ts
@@ -1,13 +1,15 @@
 import { Message } from 'node-telegram-bot-api';
 import { BaseHandler } from './BaseHandler';
 import { formatDuration } from '../../../utils/time';
+import { gitService } from '../../../services/GitService';
+import { getVersionHash } from '../../../utils/version';
 
 /**
  * Handlers for status and monitoring commands
  */
 export class StatusHandlers extends BaseHandler {
   /**
-   * /status command
+   * /status command - Show active tasks
    */
   async handleStatus(msg: Message): Promise<void> {
     if (!(await this.checkAccess(msg))) return;
@@ -30,6 +32,70 @@ export class StatusHandlers extends BaseHandler {
     }
 
     await this.bot.sendMessage(chatId, message, { parse_mode: 'Markdown' });
+  }
+
+  /**
+   * /system command - Show system configuration status
+   */
+  async handleSystem(msg: Message): Promise<void> {
+    if (!(await this.checkAccess(msg))) return;
+
+    const chatId = msg.chat.id;
+    const userId = msg.from!.id;
+
+    const statusMsg = await this.bot.sendMessage(chatId, '🔍 Checking system status...');
+
+    // Check GitHub token and auth status
+    const tokenStatus = gitService.getTokenStatus();
+    const isGhAuth = tokenStatus.configured ? await gitService.isGhAuthenticated() : false;
+
+    // Build GitHub status line with detailed feedback
+    let githubStatusLine: string;
+    let githubHelpLine = '';
+
+    if (!tokenStatus.configured) {
+      githubStatusLine = '  ❌ Not configured';
+      githubHelpLine = '  → Set `GITHUB_PAT` in Railway';
+    } else if (tokenStatus.reason === 'contains_whitespace') {
+      githubStatusLine = '  ⚠️ Token has whitespace';
+      githubHelpLine = '  → Remove spaces/newlines from `GITHUB_PAT`';
+    } else if (tokenStatus.reason === 'invalid_format') {
+      githubStatusLine = isGhAuth ? '  ⚠️ Unusual format (working)' : '  ❌ Invalid token format';
+      githubHelpLine = isGhAuth ? '' : '  → Check `GITHUB_PAT` is a valid PAT';
+    } else if (!isGhAuth) {
+      githubStatusLine = '  ❌ Token rejected';
+      githubHelpLine = '  → Verify token has "repo" scope';
+    } else {
+      githubStatusLine = '  ✅ Authenticated';
+    }
+
+    // Get current repo
+    const currentRepo = this.repositoryManager.getCurrentRepository(userId);
+    const repos = await this.repositoryManager.listRepositories(userId);
+
+    // Get version
+    const version = getVersionHash();
+
+    // Build status message
+    const lines: string[] = [
+      '⚙️ *System Status*\n',
+      '*GitHub:*',
+      githubStatusLine,
+      githubHelpLine,
+      '',
+      '*Repository:*',
+      currentRepo ? `  📁 ${currentRepo.name}` : '  ⚠️ None selected',
+      `  📊 ${repos.length} total`,
+      '',
+      '*Version:*',
+      `  \`${version}\``,
+    ].filter(Boolean);
+
+    await this.bot.editMessageText(lines.join('\n'), {
+      chat_id: chatId,
+      message_id: statusMsg.message_id,
+      parse_mode: 'Markdown'
+    });
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,12 @@ if (ENABLE_TELEGRAM && bot && handlers && chamberHandlers) {
       handler: (msg: TelegramBot.Message) => handlers.handleStatus(msg)
     },
     {
+      command: 'system',
+      description: 'Check system configuration (GitHub, etc.)',
+      pattern: /\/system/,
+      handler: (msg: TelegramBot.Message) => handlers.handleSystem(msg)
+    },
+    {
       command: 'cancel',
       description: 'Cancel an active task by ID',
       pattern: /\/cancel(.*)/,

--- a/src/services/ClaudeExecutor.ts
+++ b/src/services/ClaudeExecutor.ts
@@ -71,10 +71,14 @@ export class ClaudeExecutor extends EventEmitter {
         proc.stdin.write(githubToken);
         proc.stdin.end();
       });
-      await execAsync('gh auth setup-git', { timeout: 10000 });
+      await execAsync('gh auth setup-git', {
+        timeout: 10000,
+        env: { ...process.env, GH_TOKEN: githubToken }
+      });
       logger.info('Authenticated with GitHub CLI');
-    } catch {
-      // GitHub auth is optional
+    } catch (error) {
+      // GitHub auth is optional - log but don't fail
+      logger.debug('GitHub CLI auth setup skipped', { error: getErrorMessage(error) });
     }
   }
 

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -53,7 +53,8 @@ export class GitHubService {
   private isAuthenticated: boolean = false;
 
   constructor(token: string) {
-    this.token = token;
+    // Trim whitespace (common copy-paste issue)
+    this.token = token?.trim() || '';
   }
 
   /**
@@ -84,7 +85,9 @@ export class GitHubService {
       }
 
       // Verify authentication
-      const { stdout: statusOutput } = await execAsync('gh auth status');
+      const { stdout: statusOutput } = await execAsync('gh auth status', {
+        env: { ...process.env, GH_TOKEN: this.token }
+      });
       logger.info('GitHub authentication successful', {
         status: statusOutput.split('\n')[0]
       });
@@ -103,10 +106,13 @@ export class GitHubService {
 
   /**
    * Check if GitHub CLI is authenticated
+   * Pass GH_TOKEN env var so gh CLI can use it
    */
   async checkAuthStatus(): Promise<boolean> {
     try {
-      await execAsync('gh auth status');
+      await execAsync('gh auth status', {
+        env: { ...process.env, GH_TOKEN: this.token }
+      });
       this.isAuthenticated = true;
       return true;
     } catch {
@@ -124,6 +130,7 @@ export class GitHubService {
 
   /**
    * Execute a GitHub CLI command
+   * Pass GH_TOKEN env var so gh CLI can use it
    */
   async executeCommand(command: string): Promise<{ stdout: string; stderr: string }> {
     if (!this.isAuthenticated) {
@@ -131,7 +138,9 @@ export class GitHubService {
     }
 
     try {
-      const result = await execAsync(command);
+      const result = await execAsync(command, {
+        env: { ...process.env, GH_TOKEN: this.token }
+      });
       return result;
     } catch (error) {
       logger.error('GitHub CLI command failed', {

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -10,8 +10,10 @@ const execAsync = promisify(exec);
  */
 function sanitizeError(error: unknown): string {
   const msg = getErrorMessage(error);
-  // Redact GitHub PAT tokens (ghp_..., gho_..., ghs_..., ghr_...)
-  return msg.replace(/gh[opsr]_[a-zA-Z0-9]+/g, '[REDACTED]');
+  // Redact GitHub PAT tokens (classic and fine-grained)
+  return msg
+    .replace(/gh[opsr]_[a-zA-Z0-9_]+/g, '[REDACTED]')
+    .replace(/github_pat_[a-zA-Z0-9_]+/g, '[REDACTED]');
 }
 
 /**

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -345,13 +345,36 @@ class GitService {
   }
 
   /**
+   * Check if GitHub CLI is authenticated
+   */
+  async isGhAuthenticated(): Promise<boolean> {
+    try {
+      await execAsync('gh auth status', { timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Create GitHub repository using gh CLI
+   * Returns detailed result with error information
    */
   async createGitHubRepository(
     workingDir: string,
     isPrivate = false,
     customRepoName?: string
-  ): Promise<'success' | 'already_exists' | 'error'> {
+  ): Promise<{ status: 'success' | 'already_exists' | 'not_authenticated' | 'error'; error?: string }> {
+    // Check authentication first
+    const isAuth = await this.isGhAuthenticated();
+    if (!isAuth) {
+      logger.warn('GitHub CLI not authenticated - cannot create repository');
+      return {
+        status: 'not_authenticated',
+        error: 'GitHub CLI not authenticated. Set GITHUB_PAT environment variable.'
+      };
+    }
+
     try {
       const repoName = customRepoName || path.basename(workingDir);
       const visibility = isPrivate ? '--private' : '--public';
@@ -360,12 +383,18 @@ class GitService {
         timeout: 30000,
       });
       logger.info('Created GitHub repository', { repoName, visibility });
-      return 'success';
+      return { status: 'success' };
     } catch (error) {
       const errMsg = getErrorMessage(error);
-      if (errMsg.includes('Name already exists')) return 'already_exists';
+      if (errMsg.includes('Name already exists')) {
+        return { status: 'already_exists', error: 'Repository name already exists on GitHub' };
+      }
       logger.error('Failed to create GitHub repository', { error: errMsg });
-      return 'error';
+      // Sanitize error message (remove tokens if any)
+      const sanitizedError = errMsg
+        .replace(/gh[opsr]_[a-zA-Z0-9]+/g, '[REDACTED]')
+        .replace(/x-access-token:[^@]+@/gi, 'x-access-token:***@');
+      return { status: 'error', error: sanitizedError };
     }
   }
 

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -28,9 +28,75 @@ interface PushResult {
 
 class GitService {
   private githubToken: string | undefined;
+  private tokenValidationResult: { valid: boolean; reason?: string } | null = null;
 
   constructor() {
-    this.githubToken = process.env.GITHUB_PAT;
+    const rawToken = process.env.GITHUB_PAT;
+
+    // Trim whitespace (common copy-paste issue)
+    this.githubToken = rawToken?.trim();
+
+    // Validate and log token status on startup
+    this.validateTokenFormat();
+  }
+
+  /**
+   * Validate GitHub token format and log status
+   * Valid formats: ghp_*, gho_*, ghs_*, ghr_*, github_pat_*
+   */
+  private validateTokenFormat(): void {
+    if (!this.githubToken) {
+      this.tokenValidationResult = { valid: false, reason: 'not_set' };
+      logger.info('GitHub: GITHUB_PAT not configured - repo creation disabled');
+      return;
+    }
+
+    // Check for common issues
+    if (this.githubToken.includes(' ') || this.githubToken.includes('\n')) {
+      this.tokenValidationResult = { valid: false, reason: 'contains_whitespace' };
+      logger.error('GitHub: GITHUB_PAT contains whitespace - please check the value');
+      return;
+    }
+
+    // Validate token format - be permissive but catch obvious errors
+    // Classic PAT: ghp_, gho_, ghs_, ghr_ (40+ chars total)
+    // Fine-grained: github_pat_ (80+ chars total)
+    const isClassicPAT = /^gh[pors]_[a-zA-Z0-9_]+$/.test(this.githubToken) && this.githubToken.length >= 40;
+    const isFineGrained = this.githubToken.startsWith('github_pat_') && this.githubToken.length >= 80;
+    const looksLikeToken = isClassicPAT || isFineGrained || this.githubToken.length >= 30;
+
+    if (!looksLikeToken) {
+      this.tokenValidationResult = { valid: false, reason: 'invalid_format' };
+      logger.warn('GitHub: GITHUB_PAT appears invalid (too short or wrong format)', {
+        length: this.githubToken.length
+      });
+    } else if (!isClassicPAT && !isFineGrained) {
+      // Unknown format but reasonable length - try it anyway
+      this.tokenValidationResult = { valid: true, reason: 'unknown_format' };
+      logger.info('GitHub: GITHUB_PAT configured (unknown format, will attempt)');
+    } else {
+      this.tokenValidationResult = { valid: true };
+      const tokenType = isClassicPAT ? 'classic' : 'fine-grained';
+      logger.info(`GitHub: GITHUB_PAT configured (${tokenType} token)`);
+    }
+  }
+
+  /**
+   * Check if GitHub token is configured and valid
+   */
+  hasValidToken(): boolean {
+    return !!this.githubToken && this.tokenValidationResult?.valid !== false;
+  }
+
+  /**
+   * Get token validation status for diagnostics
+   */
+  getTokenStatus(): { configured: boolean; valid: boolean; reason?: string } {
+    return {
+      configured: !!this.githubToken,
+      valid: this.tokenValidationResult?.valid ?? false,
+      reason: this.tokenValidationResult?.reason
+    };
   }
 
   /**
@@ -345,11 +411,33 @@ class GitService {
   }
 
   /**
+   * Check if gh CLI is installed (works on Alpine Linux and other systems)
+   */
+  async isGhInstalled(): Promise<boolean> {
+    try {
+      // Use 'gh --version' instead of 'which' for better cross-platform compatibility
+      await execAsync('gh --version', { timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Check if GitHub CLI is authenticated
+   * gh CLI uses GH_TOKEN env var, so we pass GITHUB_PAT as GH_TOKEN
    */
   async isGhAuthenticated(): Promise<boolean> {
+    // If no token is set, we can't authenticate
+    if (!this.githubToken) {
+      return false;
+    }
+
     try {
-      await execAsync('gh auth status', { timeout: 5000 });
+      await execAsync('gh auth status', {
+        timeout: 5000,
+        env: { ...process.env, GH_TOKEN: this.githubToken }
+      });
       return true;
     } catch {
       return false;
@@ -365,13 +453,49 @@ class GitService {
     isPrivate = false,
     customRepoName?: string
   ): Promise<{ status: 'success' | 'already_exists' | 'not_authenticated' | 'error'; error?: string }> {
-    // Check authentication first
-    const isAuth = await this.isGhAuthenticated();
-    if (!isAuth) {
-      logger.warn('GitHub CLI not authenticated - cannot create repository');
+    // Check if gh CLI is installed
+    const ghInstalled = await this.isGhInstalled();
+    if (!ghInstalled) {
+      logger.warn('gh CLI not installed - cannot create repository');
+      return {
+        status: 'error',
+        error: 'GitHub CLI (gh) not installed in container.'
+      };
+    }
+
+    // Check token configuration with specific error messages
+    const tokenStatus = this.getTokenStatus();
+    if (!tokenStatus.configured) {
       return {
         status: 'not_authenticated',
-        error: 'GitHub CLI not authenticated. Set GITHUB_PAT environment variable.'
+        error: 'Set GITHUB_PAT in Railway environment variables.'
+      };
+    }
+
+    if (tokenStatus.reason === 'contains_whitespace') {
+      return {
+        status: 'not_authenticated',
+        error: 'GITHUB_PAT contains spaces or newlines. Remove extra whitespace.'
+      };
+    }
+
+    if (tokenStatus.reason === 'invalid_format') {
+      logger.warn('GitHub token format unrecognized, attempting anyway');
+    }
+
+    // Verify token works with gh CLI
+    const isAuth = await this.isGhAuthenticated();
+    if (!isAuth) {
+      // Provide specific guidance based on what we know
+      let errorMsg = 'GitHub authentication failed.';
+      if (tokenStatus.reason === 'invalid_format') {
+        errorMsg = 'GITHUB_PAT format invalid. Use a GitHub Personal Access Token (classic or fine-grained).';
+      } else {
+        errorMsg = 'GITHUB_PAT rejected by GitHub. Check token is valid and has "repo" scope.';
+      }
+      return {
+        status: 'not_authenticated',
+        error: errorMsg
       };
     }
 
@@ -381,6 +505,7 @@ class GitService {
       await execAsync(`gh repo create ${repoName} ${visibility} --source=. --remote=origin --push`, {
         cwd: workingDir,
         timeout: 30000,
+        env: { ...process.env, GH_TOKEN: this.githubToken }
       });
       logger.info('Created GitHub repository', { repoName, visibility });
       return { status: 'success' };

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -517,7 +517,8 @@ class GitService {
       logger.error('Failed to create GitHub repository', { error: errMsg });
       // Sanitize error message (remove tokens if any)
       const sanitizedError = errMsg
-        .replace(/gh[opsr]_[a-zA-Z0-9]+/g, '[REDACTED]')
+        .replace(/gh[opsr]_[a-zA-Z0-9_]+/g, '[REDACTED]')
+        .replace(/github_pat_[a-zA-Z0-9_]+/g, '[REDACTED]')
         .replace(/x-access-token:[^@]+@/gi, 'x-access-token:***@');
       return { status: 'error', error: sanitizedError };
     }


### PR DESCRIPTION
## Summary
- Add pre-flight authentication check before attempting to create GitHub repos
- Return detailed error messages instead of generic "creation failed"
- Show helpful guidance when `GITHUB_PAT` is not configured on Railway
- Sanitize error messages to prevent token leakage in logs/UI

## Problem
When creating a new repository via `/repo new`, the GitHub repo creation would fail silently with just "creation failed" - giving users no insight into what went wrong (usually missing `GITHUB_PAT` on Railway deployment).

## Solution
- Added `isGhAuthenticated()` check in GitService
- Changed `createGitHubRepository()` to return detailed error information
- Updated all callers (CallbackQueryHandler, RepositoryHandlers) to display meaningful messages
- Shows specific message when GitHub auth is not configured, guiding users to set `GITHUB_PAT`

## Test plan
- [ ] Deploy to Railway without GITHUB_PAT - should show "GitHub not configured" message
- [ ] Deploy with GITHUB_PAT - should create repos successfully  
- [ ] Try creating repo with existing name - should show "already exists" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)